### PR TITLE
Upload 'read_kspace.m' function and its dependencies.'

### DIFF
--- a/matlab/read_kspace.m
+++ b/matlab/read_kspace.m
@@ -1,0 +1,116 @@
+function ReconData = read_kspace(sourceDir, rawfileName, fast_read_options)
+%% Reads in data from .dat
+% ReconData = read_kspace(sourceDir, saveDir, rawfileName, fast_read_options)
+% 
+% Reads in raw kspace data from .dat file using 'fast_read_ve11.m according 
+% to options provided by fast_read_options. Reads in metadata from .dat 
+% file using multiple subfunctions (jGetFileInfo.m, fast_read_ve11.m, and 
+% mapVBVD_uk.m). Outputs all data and metadata to struct (ReconData).
+%
+% Input
+% -----
+% sourceDir : string
+%   Pathname of raw data file to read in
+% rawfileName : string
+%   Name of .dat file to read in
+% fast_read_options : cell
+%   Cell array of strings of size {1,N}. List of input options (varargin)
+%   for 'fast_read_ve11.m'
+%
+% Output
+% ------
+% ReconData : struct 
+%   Struct with fields containing the kspace data and sequence metadata
+%   ReconData.ksdata :  complex-double array (k-space data)
+%   ReconData.header :  struct  (metadata from 'jGetFileInfo.m',
+%                                'fast_read_ve11.')
+%   ReconData.noiseData : struct  (pre-scan NoiseAdjust data)
+%   ReconData.dims : cell array  (dimension order of ksdata)
+%   ReconData.fastreadOptions : cell array  (fast_read_options input var) 
+%   ReconData.shd : struct (metadata from mapVDVB_uk.m)
+%
+% Example
+% -------
+% sourceDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab...
+%                Code/mri_recon_framework/mri-recon/test-data/seg-epi/multichannel-phantom/';
+% rawfileName = 'meas_MID00262_FID27298_BRIFU_MRTI_XA50_1p2x0p6x1p8_ETL5_paddleCoil.dat';
+% fast_read_options = {'NoFillToFullFourier','ShiftDCToMatrixCenter','NoGUI',...
+%                     'LastMeasDatOnly','CollapseSeg','ReadNoiseAdj'};
+% >>ReconData = read_kspace(sourceDir, rawfileName, fast_read_options);
+%% Created 2024-04-02 Sara L. Johnson, Sam Adams-Tew
+
+
+%%%~~~ Inspect variables, specify defaults ~~~~%%%
+
+% Specify default fast_read_ve11 options
+if ~exist('fast_read_options', 'var')  
+    fast_read_options = {'NoFillToFullFourier',...
+                        'ShiftDCToMatrixCenter',...
+                        'NoGUI',...
+                        'LastMeasDatOnly',...
+                        'CollapseSeg',...
+                        'ReadNoiseAdj'};
+end 
+
+%%%~~~ Begin reading data ~~~~%%%
+
+fullfilename = fullfile(sourceDir, rawfileName); 
+
+% Get k-space 'header' from .dat metadata (J. Mendez)
+fileInfo=jGetFileInfo(fullfilename);
+header = fileInfo.Protocol(end); 
+
+% Check if MRI acquisition isMultislice
+if (length(header.sSliceArray.asSlice)) > 1
+    isMultislice = 1;
+else 
+    isMultislice = 0;
+end
+
+% FAST_READ_ve11: Get k-space data from .dat
+if isMultislice
+
+    % for Multislice, get additional info from .dat metadata
+    fast_read_options = cat(2, fast_read_options,...
+                               {'ReadRelSliceNumber',...
+                                'ReadSVector',...
+                                'ReadQuaternion'}); 
+
+    % read in kspace and Multislice metadata
+    [measData, relSliceNo] = fast_read_ve11(fullfilename,...
+                                            fast_read_options{:}); 
+
+    % append Multislice metadata to 'header'
+    header.multiSlice.relSliceNumber = relSliceNo; 
+    header.multiSlice.sliceVectors = measData{end}.SVector; 
+    header.multiSlice.slabQuaternion = measData{end}.Quaternion; 
+
+else
+
+    % read in kspace 
+    measData = fast_read_ve11(fullfilename,...
+                              fast_read_options{:}); 
+end 
+
+% mapVBVD_UK: Get additional metadata from .dat
+twix_obj = mapVBVD_uk(fullfilename);
+
+if size(twix_obj, 2) > 1
+    shd = getshd(twix_obj{1}, twix_obj{end});
+else
+    shd = getshd(twix_obj, twix_obj);
+end
+
+
+%%%~~~ Store data output ~~~~%%%
+
+% Store kspace data and metadata 
+ReconData.ksdata = measData{end}.data;
+ReconData.header = header; 
+ReconData.noiseData = measData{1}.noiseAdj;
+ReconData.dims = measData{end}.dim;
+ReconData.fastreadOptions = fast_read_options; 
+ReconData.shd = shd;
+
+
+end 

--- a/matlab/read_kspace_dependencies/fast_read_ve11.m
+++ b/matlab/read_kspace_dependencies/fast_read_ve11.m
@@ -1,0 +1,2823 @@
+% =============================================================================
+function [KSpace, varargout] = fast_read_ve11(filenameIn,varargin)
+% -----------------------------------------------------------------------------
+% fast_read_ve11  Read a VE11 measurement data file with the property that all 
+%                  lines for a given measurement have the same number of 
+%                  samples.  This differs slightly from the VB reader 
+%                  where only one measurement was stored per file.  VD can
+%                  store multiple measurementhes.
+%
+% KSpace = fast_read_ve11() 
+%    prompts user with gui and returns kSpace cell array, each cell storing
+%               the kSpace from a particular measurement.
+%
+% KSpace = fast_read_ve11(filename, 'option1', 'option2', 'option3', ....)
+%    reads filename and returns kspace with options applied where
+%    options are strings
+%
+% fast_read_ve11 with no arguments or return values will list options
+%
+% [KSpace Other] = fast_read_ve11(filename, 'ReadOther') 
+%    reads filename and returns kSpace as well as Other if it exists where
+% -----------------------------------------------------------------------------
+
+   global MDH_SCANSIZE MDH_CHANSIZE MAX_BYTES_PER_FREAD
+   global index_keys
+   global mdhColumns mdhBitFlag
+
+   %% Nested functions (share parent's scope)
+   function set_outputs_to_zero
+      KSpace{1}.data = [];
+      for iArgLocal=1:nargout-1
+         varargout{iArgLocal} = [];
+      end
+      if ~(Control.User.noGui || Control.User.silent)
+         if ~isempty(Control.GUI.hWaitBar)
+            close(Control.GUI.hWaitBar);
+         end
+      end
+   end
+
+   if (nargin == 0) && (nargout == 0)
+      UserInputDefault = define_user_input_default_struct_array;
+      UserInputDefault = derive_user_input_default_fieldname(UserInputDefault);
+      print_available_options(UserInputDefault);
+      return
+   end
+
+   % Initializing
+   KSpace{1}.data = [];
+   for iArg=1:nargout-1
+      varargout{iArg} = [];
+   end
+   nOptionsIn = nargin-1;
+   if nOptionsIn > 0
+      optionsIn = varargin;
+   else
+      optionsIn = [];
+   end
+   set_global_mdh_parameters(filenameIn);
+
+   Control = get_controls_from_user_input(filenameIn, optionsIn, nargin, nargout);
+   if isempty(Control)
+      set_outputs_to_zero;
+      return
+   end
+   if Control.User.readFileInfo
+      if length(which('jGetFileInfo')) < 1
+         disp('jGetFileInfo not in path');
+         set_outputs_to_zero;
+         return
+      end
+   end
+
+   if ~(Control.User.noGui || Control.User.silent)
+      Control.GUI.hWaitBar = waitbar(0, 'Extracting TextHeader', 'Name', 'Progress', 'Resize', 'on');
+      set(findall(Control.GUI.hWaitBar), 'Units', 'Normalized');
+      set(Control.GUI.hWaitBar, 'Units', 'Pixels', 'Position', [100 100 400 150]);
+      movegui(Control.GUI.hWaitBar, 'center');
+   end
+
+   % Read noise if indicated
+   if Control.User.readNoiseAdj
+      mdhBitFlagPrev = mdhBitFlag;
+      KNoise = fast_read_ve11(filenameIn, 'KeepBitMask', '2000000', 'LogicKeepOnly', 'NoFillToFullFourier', 'Silent');
+      mdhBitFlag= mdhBitFlagPrev;
+   end
+
+   fid = fopen(Control.File.In.name,'r','ieee-le');
+
+   % Confirm that we have a ve11 file
+   [isVE11, MrParcRaidFileHeader, MrParcRaidFileCell] = is_ve11_file(Control, fid);
+   if ~isVE11
+      set_outputs_to_zero;
+      return
+   end
+
+   % Swap SEG and ECO indices
+   % This was introduced to handle HIFU meas dat where they used PHASCOR flags
+   %    to store special navigators.  Unfortunately, they were stored in a way
+   %    contrary to how PHASCOR are stored in general.  To read them, turn on
+   %    the KeepBitFlag for phasecor and add 'SwapSegAndEco' to the call parameters.
+   if Control.User.swapSegAndEco
+      temp = mdhColumns.scan.indexECO;
+      mdhColumns.scan.indexECO = mdhColumns.scan.indexSEG;
+      mdhColumns.scan.indexSEG = temp;
+      clear temp
+   end
+
+   % Loop through measurements
+   RelativeSliceNumber = {};
+   WiPMemBlock = {};
+   SliceArray = {};
+   indexOutTemp = uint64([0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]);
+   for iMeas = 1:MrParcRaidFileHeader.nMeas
+
+      if Control.User.readNoiseAdj 
+         KSpace{iMeas}.noiseAdj = KNoise{iMeas};
+      end
+
+      nNormalThisMeas = 0;
+      if Control.User.lastMeasDatOnly && (iMeas < MrParcRaidFileHeader.nMeas)
+         KSpace{iMeas}.data = [];
+         continue
+      end
+
+      % Parse the text header for dimensions, scale factors, control, etc.
+      [Control, MrParcRaidFileCell, Dim, CoilSelectMap, TextHeader, ...
+       CoilSelectMeasMap, RelativeSliceNumberLocal, WiPMemBlockLocal, SliceArrayLocal, MeasYapsAsc] = ...
+          parse_meas_text_header(Control,fid,MrParcRaidFileCell,iMeas);
+      if isempty(Control)
+         set_outputs_to_zero;
+         return
+      end
+      RelativeSliceNumber{iMeas} = RelativeSliceNumberLocal;
+      WiPMemBlock{iMeas} = WiPMemBlockLocal;
+      SliceArray{iMeas} = SliceArrayLocal;
+
+      % First pass to chunk this measurement into blocks with the same scan lengths
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(0.5, Control.GUI.hWaitBar, 'Measuring number of scans');
+      end
+
+      % With readout and PMU being different sizes, 
+      %    we now have to chunk in blocks of same sized
+      %    lines.  That requires scanning all line lengths
+      %    up front.
+      if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+          evalMaskArray = chunk_into_equal_line_length_blocks2(fid,MrParcRaidFileCell, iMeas, Dim, Control);
+          display_eval_mask(evalMaskArray,iMeas);
+          continue
+      else
+         [~, sizeAllScansInBytes, sizeChanInBytes, MdhBlock, ...
+          nBlockSYNCDATA, ~, ~, ~, ...
+          nScanInMeas, ~, nSamplesInScan] = chunk_into_equal_line_length_blocks2(fid,MrParcRaidFileCell, iMeas, Dim, Control);
+         if isempty(sizeAllScansInBytes)
+            KSpace{iMeas}.data = [];
+            continue
+         end
+      end
+
+      % Second pass, Part 1 to extract PMU
+      if (nBlockSYNCDATA > 0) && MrParcRaidFileCell{iMeas}.Control.User.readPMU
+         PMUOutCell{iMeas} = extract_pmu(fid,MdhBlock,Control);
+         if isempty(PMUOutCell{iMeas})
+            set_outputs_to_zero;
+            return
+         end
+      end % if we're loading PMU
+
+      % Second pass, Part 2 to assemble dimensions and read order for readouts
+      [dimNames, nScan, n, kSpaceCentreLineNo, kSpaceCentrePartitionNo, ...
+         order, dimOut, dimOutProd, channelIDUniq] = ...
+         scan_mdh_for_dim_and_order(fid,Dim,MrParcRaidFileCell{iMeas}.Control,sizeChanInBytes,MdhBlock,nScanInMeas,nSamplesInScan);
+      if isempty(dimNames)
+         set_outputs_to_zero;
+         return
+      end
+
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(1.0, Control.GUI.hWaitBar, 'Output dimensions computed.');
+      end
+
+      % Third pass to read the data
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(0.0, Control.GUI.hWaitBar, 'Allocating arrays');
+      end
+
+      % Allocate arrays
+      %keyboard
+      progressPercent = 0.0;
+      mdhExtrasToRead = {};
+      if nScan > 0 && ~Control.User.noKSpace
+         Control.User.foundNormal = true;
+         KSpace{iMeas}.data = complex(single(0) * zeros(n.COL, compute_product(dimOut), 'single'),single(0));
+         if Control.User.readIceProgramParam
+             mdhExtrasToRead = [mdhExtrasToRead {'iceProgramPara'}];
+             KSpace{iMeas}.IceProgramPara = zeros(28, compute_product(dimOut),'uint16');
+         end
+         for readStrStub = {'SVector', 'Quaternion'}
+            readStr = ['read' readStrStub{1}];
+            if Control.User.(readStr)
+               mdhExtrasToRead = [mdhExtrasToRead {[lower(readStrStub{1}(1)) readStrStub{1}(2:end)]}];
+               KSpace{iMeas}.(readStrStub{1}).vec2index = {};
+               KSpace{iMeas}.(readStrStub{1}).index2vec = {};
+               if strcmp(readStrStub{1},'Quaternion')
+                   KSpace{iMeas}.(readStrStub{1}).index2rot = {};
+               end
+               KSpace{iMeas}.(readStrStub{1}).index = uint8(0) * zeros(1, compute_product(dimOut),'uint8');
+            end
+         end
+         for readStrStub = {'TimeStamp', 'PMUTimeStamp', 'TimeSinceLastRF', 'SequenceTime'}
+            readStr = ['read' readStrStub{1}];
+            if Control.User.(readStr)
+               mdhExtrasToRead = [mdhExtrasToRead {[lower(readStrStub{1}(1)) readStrStub{1}(2:end)]}];
+               KSpace{iMeas}.(readStrStub{1}).count = 0 * zeros(compute_product(dimOut),1);
+               KSpace{iMeas}.(readStrStub{1}).value = uint32(0) * zeros(compute_product(dimOut),1,'uint32');
+            end
+         end
+      else
+          KSpace{iMeas}.data = [];
+      end
+
+      progressPercent = progressPercent + 0.25;
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(progressPercent, Control.GUI.hWaitBar, 'Allocating arrays');
+      end
+      
+      iScanRead = uint64(0);
+      timeRemain = uint64(10000000);
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         time0 = tic;
+         time00 = tic;
+      end
+
+      for iBlock=1:length(MdhBlock)
+
+         if Control.User.noKSpace
+             continue
+         end
+
+         % Skip SYNCDATA
+         if MdhBlock(iBlock).isSyncData || MdhBlock(iBlock).isAcqEnd || ~MdhBlock(iBlock).keepScan 
+            continue
+         end
+         iReadout = uint64(1):uint64(MdhBlock(iBlock).nSamplesInScan);
+
+         maxScanPerRead = max(idivide(MAX_BYTES_PER_FREAD,MdhBlock(iBlock).dmaLength,'fix'),uint64(1));
+         nScanToRead = min(maxScanPerRead,MdhBlock(iBlock).nScan);
+
+         fseek(fid,MdhBlock(iBlock).offsetInFile,'bof');
+         nScanRemainInBlock = MdhBlock(iBlock).nScan;
+      
+         iScanReadBlock = uint64(0);
+         while nScanRemainInBlock > 0
+
+            if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+               dTimeElapsed = toc(time0);
+               rate = dTimeElapsed / (double(iScanRead) + 1);
+               if dTimeElapsed > 20
+                  timeRemain = min(double(nScanInMeas - iScanRead) * rate,timeRemain);
+               else
+                  timeRemain = double(nScanInMeas - iScanRead) * rate;
+               end
+               %textMessage = sprintf('Pass 3 of 3\nReading scans\nNormal lines so far:%d\nTime remaining (s): %d', nNormalThisMeas, uint32(timeRemain));
+               textMessage = sprintf('Pass 3 of 3\nReading scans\nTime remaining (s): %d', uint32(timeRemain));
+               waitbar(double(iScanRead)/double(nScanInMeas), Control.GUI.hWaitBar, textMessage);
+            end
+            blockOfScans = fread(fid,[MdhBlock(iBlock).dmaLength nScanToRead],'uchar=>uchar');
+            MdhParam = extract_mdh_parameters(blockOfScans, 'scan', [mdhExtrasToRead {'cutOffDataPre', 'cutOffDataPost'} index_keys]);
+            if MrParcRaidFileCell{iMeas}.Control.User.collapseSeg
+               MdhParam.indexSEG = MdhParam.indexSEG * uint16(0);
+            end
+            MdhBitFlags = extract_mdh_bitflags(blockOfScans, {'isAcqEnd', 'bKeepEIM', 'bDropEIM', 'isNoiseAdj', 'isPhaseCor', 'isRawDataCorrection','isReflect'});
+
+            for indexStr = index_keys
+               MdhParam.(indexStr{1}) = uint64(MdhParam.(indexStr{1}));
+            end
+            channelID = uint16(0) * zeros(MdhBlock(iBlock).nChannelUsed,nScanToRead,'uint16');
+            for iCha = 1:MdhBlock(iBlock).nChannelUsed
+               offset  = uint64(MDH_SCANSIZE) + uint64(iCha-1) * sizeChanInBytes;
+               channelID(iCha,:) = reshape(extract_single_mdh_parameter(blockOfScans(offset+1:offset+sizeChanInBytes,:),'chan','channelID'),[1,nScanToRead]);
+            end
+            if Control.User.readSequenceTime
+               iCha = 1;
+               offset  = uint64(MDH_SCANSIZE) + uint64(iCha-1) * sizeChanInBytes;
+               sequenceTime = bitshift(extract_single_mdh_parameter(blockOfScans(offset+1:offset+sizeChanInBytes,:),'chan','sequenceTime'),-9);
+            end
+            sizeSamplesInBytes = MdhBlock(iBlock).nSamplesInScan * uint64(8);
+            for iCha = 1:MdhBlock(iBlock).nChannelUsed
+
+               channelIDOut = squeeze(channelID(iCha,:));
+               offset  = uint64(MDH_SCANSIZE) + uint64(iCha-1) * sizeChanInBytes + MDH_CHANSIZE + uint64(1);
+
+               tempArr = blockOfScans(offset:offset+sizeSamplesInBytes-1,:);
+               tempArr = reshape(typecast(tempArr(:),'single'), [2*MdhBlock(iBlock).nSamplesInScan nScanToRead]);
+               tempArr = complex(tempArr(1:2:end,:),tempArr(2:2:end,:));
+
+               % Handle all the reflections at once
+               indexReflect = find(MdhBitFlags.isReflect);
+               if ~isempty(indexReflect)
+                  tempArr(:,indexReflect) = flipud(tempArr(:,indexReflect));
+               end
+
+               % Handle Pre-cutoff
+               indexPre = find(MdhParam.cutOffDataPre > 0 & ~MdhBitFlags.isNoiseAdj);
+               if ~isempty(indexPre)
+                  cutOffDataPreUniq = unique(MdhParam.cutOffDataPre(indexPre));
+                  for iUniq = 1:numel(cutOffDataPreUniq)
+                     indexCut = find(MdhParam.cutOffDataPre(indexPre) == cutOffDataPreUniq(iUniq));
+                     tempArr(1:cutOffDataPreUniq(iUniq),indexPre(indexCut)) = ...
+                        complex(zeros(cutOffDataPreUniq(iUniq),numel(indexCut),'single'),single(0));
+                  end % loop over uniq cuts
+               end
+
+               % Handle Post-cutoff
+               indexPost = find(MdhParam.cutOffDataPost > 0 & ~MdhBitFlags.isNoiseAdj);
+               if ~isempty(indexPost)
+                  cutOffDataPostUniq = unique(MdhParam.cutOffDataPost(indexPost));
+                  for iUniq = 1:numel(cutOffDataPostUniq)
+                     indexCut = find(MdhParam.cutOffDataPost(indexPost) == cutOffDataPostUniq(iUniq));
+                     tempArr(end-cutOffDataPostUniq(iUniq)+1:end,indexPost(indexCut)) = ...
+                        complex(zeros(cutOffDataPostUniq(iUniq),numel(indexCut),'single'),single(0));
+                  end % loop over uniq cuts
+               end
+
+               maskKeep = ~MdhBitFlags.isAcqEnd;
+               index = find(maskKeep);
+               if ~(numel(index) > 0)
+                  continue;
+               end
+               % Pass through to sort optimally
+               if Control.User.applySortAlgorithm
+                  kScanTest = zeros(numel(index),1,'uint64');
+                  for kScan = 1:numel(index)
+                     jScan = index(kScan);
+                     indexCHA = find(channelIDUniq == channelIDOut(jScan)) - 1;
+                     indexOutTemp(1) = indexCHA;
+                     indexOutTemp(2) = MdhParam.indexLIN(jScan);
+                     indexOutTemp(3) = MdhParam.indexSLC(jScan);
+                     indexOutTemp(4) = MdhParam.indexPAR(jScan);
+                     indexOutTemp(5) = MdhParam.indexACQ(jScan);
+                     indexOutTemp(6) = MdhParam.indexECO(jScan);
+                     indexOutTemp(7) = MdhParam.indexPHS(jScan);
+                     indexOutTemp(8) = MdhParam.indexREP(jScan);
+                     indexOutTemp(9) = MdhParam.indexSET(jScan);
+                     indexOutTemp(10) = MdhParam.indexSEG(jScan);
+                     indexOutTemp(11) = MdhParam.indexIDA(jScan);
+                     indexOutTemp(12) = MdhParam.indexIDB(jScan);
+                     indexOutTemp(13) = MdhParam.indexIDC(jScan);
+                     indexOutTemp(14) = MdhParam.indexIDD(jScan);
+                     indexOutTemp(15) = MdhParam.indexIDE(jScan);
+                     indexOut = mod(indexOutTemp(order),dimOut);
+                     kScanTest(kScan,1) = sum(indexOut(:) .* dimOutProd(:)) + uint64(1);
+                  end
+                  [~,kScanSortIndex] = sort(kScanTest);
+               else
+                  kScanSortIndex = 1:numel(index);
+               end
+               for kScan = 1:numel(index)
+                  if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+                     dTimeElapsed00 = toc(time00);
+                     if dTimeElapsed00 > 5
+                        dTimeElapsed = toc(time0);
+                        rate = dTimeElapsed / (double(iScanRead+kScan) + 1);
+                        if dTimeElapsed > 20
+                           timeRemain = min(double(nScanInMeas - iScanRead - kScan) * rate,timeRemain);
+                        else
+                           timeRemain = double(nScanInMeas - iScanRead - kScan) * rate;
+                        end
+                        time00 = tic;
+                        %textMessage = sprintf('Pass 3 of 3\nReading scans\nNormal lines so far:%d\nTime remaining (s): %d', nNormalThisMeas, uint32(timeRemain));
+                        textMessage = sprintf('Pass 3 of 3\nReading scans\nTime remaining (s): %d', uint32(timeRemain));
+                        waitbar(double(iScanRead+kScan)/double(nScanInMeas), Control.GUI.hWaitBar, textMessage);
+                     end
+                  end
+                  jScan = index(kScanSortIndex(kScan));
+                  keyCHACoilSelectMeas = channelIDOut(jScan) + 1;
+                  keyCHACoilSelect = CoilSelectMeasMap{keyCHACoilSelectMeas}.tElement;
+                  indexCHA = find(channelIDUniq == channelIDOut(jScan)) - 1;
+                  indexOutTemp(1) = indexCHA;
+                  indexOutTemp(2) = MdhParam.indexLIN(jScan);
+                  indexOutTemp(3) = MdhParam.indexSLC(jScan);
+                  indexOutTemp(4) = MdhParam.indexPAR(jScan);
+                  indexOutTemp(5) = MdhParam.indexACQ(jScan);
+                  indexOutTemp(6) = MdhParam.indexECO(jScan);
+                  indexOutTemp(7) = MdhParam.indexPHS(jScan);
+                  indexOutTemp(8) = MdhParam.indexREP(jScan);
+                  indexOutTemp(9) = MdhParam.indexSET(jScan);
+                  indexOutTemp(10) = MdhParam.indexSEG(jScan);
+                  indexOutTemp(11) = MdhParam.indexIDA(jScan);
+                  indexOutTemp(12) = MdhParam.indexIDB(jScan);
+                  indexOutTemp(13) = MdhParam.indexIDC(jScan);
+                  indexOutTemp(14) = MdhParam.indexIDD(jScan);
+                  indexOutTemp(15) = MdhParam.indexIDE(jScan);
+                  temp = tempArr(:,jScan);
+                  indexOut = mod(indexOutTemp(order),dimOut);
+                  iScan = sum(indexOut(:) .* dimOutProd(:)) + uint64(1);
+                  if MdhBitFlags.isRawDataCorrection(jScan) && Control.User.applyRawDataCorrection
+                     temp = CoilSelectMap.(keyCHACoilSelect).rawDataCorrectionFactor*temp;
+                  end
+                  if Control.User.useMexInsertion
+                     copy_column_a2b_single_complex(CoilSelectMeasMap{keyCHACoilSelectMeas}.flFFTCorrectionFactor*temp, ...
+                                                    KSpace{iMeas}.data,double(iReadout(1)),double(iScan));
+                  else
+                     temp = CoilSelectMeasMap{keyCHACoilSelectMeas}.flFFTCorrectionFactor*temp;
+                     KSpace{iMeas}.data(iReadout,iScan) = temp;
+                  end
+                  nNormalThisMeas = nNormalThisMeas + length(indexOut(:));
+                  if Control.User.readIceProgramParam
+                      KSpace{iMeas}.IceProgramPara(:,iScan) = MdhParam.iceProgramPara(:,jScan);
+                  end
+                  for readStrStub = {'SVector', 'Quaternion'}
+                     readStr = ['read' readStrStub{1}];
+                     mdhStr = [lower(readStrStub{1}(1)) readStrStub{1}(2:end)];
+                     if Control.User.(readStr)
+                        if strcmp(readStrStub{1}, 'SVector')
+                            vectorStr = num2str(MdhParam.(mdhStr)((jScan-1)*3+1:jScan*3)','%f_%f_%f');
+                        else
+                            vectorStr = num2str(MdhParam.(mdhStr)((jScan-1)*4+1:jScan*4)','%f_%f_%f_%f');
+                        end
+                        vectorStr = strrep(vectorStr, '-', 'm');
+                        vectorStr = strrep(vectorStr, '.', 'd');
+                        vectorStr = ['v' vectorStr];
+                        if length(KSpace{iMeas}.(readStrStub{1}).vec2index) > 0 && isfield(KSpace{iMeas}.(readStrStub{1}).vec2index, vectorStr)
+                            iData = KSpace{iMeas}.(readStrStub{1}).vec2index.(vectorStr);
+                        else
+                            if length(KSpace{iMeas}.(readStrStub{1}).vec2index) > 0
+                                iData = length(fieldnames(KSpace{iMeas}.(readStrStub{1}).vec2index)) + 1; 
+                            else
+                                iData = 1; 
+                            end
+                            KSpace{iMeas}.(readStrStub{1}).vec2index.(vectorStr) = iData;
+                            if strcmp(readStrStub{1}, 'SVector')
+                                KSpace{iMeas}.(readStrStub{1}).index2vec{iData} = MdhParam.(mdhStr)((jScan-1)*3+1:jScan*3)';
+                            else
+                                KSpace{iMeas}.(readStrStub{1}).index2vec{iData} = MdhParam.(mdhStr)((jScan-1)*4+1:jScan*4)';
+                                [q_status, rot_matrix] = quaternion_to_rotation_matrix(MdhParam.(mdhStr)((jScan-1)*4+1:jScan*4)');
+                                KSpace{iMeas}.(readStrStub{1}).index2rot{iData} = rot_matrix;
+                            end
+                        end
+                        KSpace{iMeas}.(readStrStub{1}).index(iScan) = iData;
+                     end
+                  end
+                  for readStrStub = {'TimeStamp', 'PMUTimeStamp', 'TimeSinceLastRF', 'SequenceTime'}
+                     readStr = ['read' readStrStub{1}];
+                     mdhStr = [lower(readStrStub{1}(1)) readStrStub{1}(2:end)];
+                     if Control.User.(readStr)
+                         KSpace{iMeas}.(readStrStub{1}).count(iScan) = KSpace{iMeas}.(readStrStub{1}).count(iScan) + 1;
+                         nValues = KSpace{iMeas}.(readStrStub{1}).count(iScan);
+                         if strcmp(readStrStub{1}, 'SequenceTime')
+                            KSpace{iMeas}.(readStrStub{1}).value(iScan,nValues) = sequenceTime(iScan);
+                         else
+                            KSpace{iMeas}.(readStrStub{1}).value(iScan,nValues) = MdhParam.(mdhStr)(jScan);
+                         end
+                     end
+                  end
+               end % loop over kScan
+
+            end % endfor over channels
+
+            iScanRead = iScanRead + nScanToRead;
+            iScanReadBlock = iScanReadBlock + nScanToRead;
+            nScanRemainInBlock = MdhBlock(iBlock).nScan - iScanReadBlock;
+            nScanToRead = min(nScanToRead,nScanRemainInBlock);
+
+         end % while over sub-blocks of lines
+      end % for over MdhBlocks
+      clear blockOfScans;
+      clear index;
+      clear tempArr;
+      clear channelID channelIDOut MdhParam MdhBitFlags;
+      clear iScanRead iScanReadBlock nScanToRead;
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(0.5, Control.GUI.hWaitBar, 'All lines read from file.  Reshaping.');
+      end
+
+      % Reshape the results
+      indexDimNonZero = find(dimOut > 1);
+      if isempty(indexDimNonZero)
+         indexDimNonZeroTemp = find(dimOut(1:end) > 0); 
+         indexDimNonZero = zeros(1,1);
+         indexDimNonZero(1) = indexDimNonZeroTemp(1);
+      end
+      if ~isempty(KSpace{iMeas}.data)
+         KSpace{iMeas}.data = reshape(KSpace{iMeas}.data, [n.COL dimOut(indexDimNonZero)]);
+         if Control.User.readIceProgramParam
+            KSpace{iMeas}.IceProgramPara = reshape(KSpace{iMeas}.IceProgramPara, [28 dimOut(indexDimNonZero)]);
+         end
+         for readStrStub = {'SVector', 'Quaternion'}
+            readStr = ['read' readStrStub{1}];
+            if Control.User.(readStr)
+                KSpace{iMeas}.(readStrStub{1}).index = reshape(KSpace{iMeas}.(readStrStub{1}).index, dimOut(indexDimNonZero));
+            end
+         end
+         for readStrStub = {'TimeStamp', 'PMUTimeStamp', 'TimeSinceLastRF', 'SequenceTime'}
+            readStr = ['read' readStrStub{1}];
+            if Control.User.(readStr)
+               dSize = max(KSpace{iMeas}.(readStrStub{1}).count(:));
+               if n.CHA > 1
+                  if length(indexDimNonZero(2:end)) > 1 
+                     newDim = dimOut(indexDimNonZero(2:end));
+                  else
+                     newDim = [1 dimOut(indexDimNonZero(2:end))];
+                  end
+                  KSpace{iMeas}.(readStrStub{1}).count = reshape(KSpace{iMeas}.(readStrStub{1}).count(1:uint64(n.CHA):end), newDim);
+                  KSpace{iMeas}.(readStrStub{1}).value = reshape(KSpace{iMeas}.(readStrStub{1}).value(1:uint64(n.CHA):end,:), [newDim dSize]);
+               else
+                  if length(indexDimNonZero) > 1 
+                     newDim = dimOut(indexDimNonZero);
+                  else
+                     newDim = [1 dimOut(indexDimNonZero)];
+                  end
+                  KSpace{iMeas}.(readStrStub{1}).count = reshape(KSpace{iMeas}.(readStrStub{1}).count, newDim);
+                  KSpace{iMeas}.(readStrStub{1}).value = reshape(KSpace{iMeas}.(readStrStub{1}).value, [newDim dSize]);
+               end
+            end
+         end
+      end
+
+      if MrParcRaidFileCell{iMeas}.Control.User.shiftDCToMatrixCenter == true
+         if nScan > 0 && ~Control.User.noKSpace
+            allShift = dimOut * 0;
+            colShift = idivide(n.COL - nSamplesInScan, uint64(2), 'fix');
+            iLin = find(order == 2);
+            if dimOut(iLin(1)) > 1
+               linShift = uint64(dimOut(iLin(1))/2) - uint64(kSpaceCentreLineNo);
+               allShift(iLin(1)) = linShift;
+            end
+            iPar = find(order == 4);
+            if dimOut(iPar(1)) > 1
+               parShift = uint64(dimOut(iPar(1))/2) - uint64(kSpaceCentrePartitionNo);
+               allShift(iPar(1)) = parShift;
+            end
+            allShift = [colShift allShift(indexDimNonZero)];
+            KSpace{iMeas}.data = circshift(KSpace{iMeas}.data,allShift);
+         end
+      end
+
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         waitbar(1.0, Control.GUI.hWaitBar, 'KSpace complete.');
+      end
+
+      tMsg = ['No scans read this measUID: ' MrParcRaidFileCell{iMeas}.Control.File.measUIDString];
+      if nScan > 0
+         tMsg = sprintf('KSpace dimensions:\n   COL=%d', n.COL);
+         dimNamesOut = dimNames(order);
+         for iDim=1:numel(indexDimNonZero)
+            tMsg = strcat(tMsg, sprintf('\n   %s=%d', ...
+                                        dimNamesOut{indexDimNonZero(iDim)}, ...
+                                        dimOut(indexDimNonZero(iDim))));
+         end
+         KSpace{iMeas}.dim = ['COL', dimNamesOut(indexDimNonZero)];
+      end
+
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui, ...
+                         'WAIT', tMsg,'Output KSpace Dimensions');
+      end
+
+      KSpace{iMeas}.TextHeader = TextHeader;
+      KSpace{iMeas}.Protocol.Dim = Dim;
+      KSpace{iMeas}.Protocol.Misc.kSpaceCentreLineNo = kSpaceCentreLineNo;
+      KSpace{iMeas}.Protocol.Misc.kSpaceCentrePartitionNo = kSpaceCentrePartitionNo;
+      KSpace{iMeas}.Protocol.CoilSelectMap = CoilSelectMap;
+      KSpace{iMeas}.Protocol.CoilSelectMeasMap = CoilSelectMeasMap;
+      KSpace{iMeas}.Protocol.MeasYapsAscConv = MeasYapsAsc;
+      KSpace{iMeas}.Protocol.ChannelID = channelIDUniq;
+
+      clear Dim CoilSelectMap CoilSelectMeasMap n MeasYapsAsc;
+
+   end % endfor over all measurements in file
+   if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+      close(Control.GUI.hWaitBar);
+   end
+   fclose(fid);
+
+   if Control.User.readPMU
+      varargout{Control.User.iArgOutPMU} = PMUOutCell;
+   end
+   if and(Control.User.foundSliceArray,Control.User.readSliceArray)
+      varargout{Control.User.iArgOutSliceArray} = SliceArray;
+   end
+   if and(Control.User.foundWiPMemBlock,Control.User.readWiPMemBlock)
+      varargout{Control.User.iArgOutWiPMemBlock} = WiPMemBlock;
+   end
+   if and(Control.User.foundRelSliceNumber,Control.User.readRelSliceNumber)
+      varargout{Control.User.iArgOutRelSliceNumber} = RelativeSliceNumber;
+   end
+   if Control.User.readFileInfo
+      varargout{Control.User.iArgOutFileInfo} = jGetFileInfo(filenameIn);
+   end   
+
+end
+
+% =============================================================================
+function UserInputDefault = define_user_input_default_struct_array
+% -----------------------------------------------------------------------------
+% Return struct array of user defaults:
+%    UserInputDefault(i).varArgIn - string to expect from varargin
+%    UserInputDefault(i).fieldName - defines structure field name to associate 
+%                                with input.  If empty string, then same as 
+%                                varArgIn with first letter lower case.
+%    UserInputDefault(i).defaultValue - default value
+%    UserInputDefault(i).type - currently: 'logical','hex2dec'
+%    UserInputDefault(i).isArgOut - boolean
+%    UserInputDefault(i).description
+% -----------------------------------------------------------------------------
+
+   userInputFieldNames = ...
+         {{'varArgIn'},      {'fieldName'}, {'defaultValue'},    {'type'}, {'isArgOut'}, {'description'} };
+   userInputValues = ...
+      { ...
+         {{'ApplyRawDataCorrection'}, {''},          {false}, {'logical'},      {false}, {'Apply raw data correction to (usually central TSE) lines based on mdh flag and gain parameters in the header.'}}, ...
+         {{'ApplySortAlgorithm'},     {''},          {false}, {'logical'},      {false}, {'In some cases this algorithm might speed things up'}}, ...
+         {{'ScanEvalInfoMaskOnly'},   {''},          {false}, {'logical'},      {false}, {'Scans the meas.dat file to record the set of evalinfomask bitmasks encountered.  Useful when later constructing keep/drop masks'}}, ...
+         {{'DropBitMask'},            {''},     {'8000002604406'}, {'hex2dec'},      {false}, {'hex string bit mask for first evalInfoMask controlling what lines are dropped.'}}, ...
+         {{'DropMatchAllBits'},       {''},          {false}, {'logical'},      {false}, {'MDH bits must match DropBitMask exactly to trigger true.  Otherwise any matched bit will trigger true.'}}, ...
+         {{'KeepBitMask'},            {''},     {'fd9fbbf9'}, {'hex2dec'},      {false}, {'hex string bit mask for first evalInfoMask controlling what lines are kept.'}}, ...
+         {{'KeepMatchAllBits'},       {''},          {false}, {'logical'},      {false}, {'MDH bits must match KeepBitMask exactly to trigger true.  Otherwise any matched bit will trigger true.'}}, ...
+         {{'LogicKeepOnly'},          {''},          {false}, {'logical'},      {false}, {'Standard logic is (keep and not drop).  However, we can ignore the drop mask.  Lines are kept when keep condition is true.'}}, ...
+         {{'LogicDropOnly'},          {''},          {false}, {'logical'},      {false}, {'Standard logic is (keep and not drop).  However, we can ignore the keep mask.  Lines are kept when drop condition is false.'}}, ...
+         {{'LastMeasDatOnly'},        {''},          {false}, {'logical'},      {false}, {'Read only the last meas.dat block in the multi-measure meas.dat file.'}}, ...
+         {{'NoFillToFullFourier'},    {''},          {false}, {'logical'},      {false}, {'Do NOT Fill k-space matrix out to complete FFT size in case of partial-Fourier acquisitions.'}}, ...
+         {{'NoGui'},                  {''},          {false}, {'logical'},      {false}, {'Do not display GUI elements.'}}, ...
+         {{'NoKSpace'},               {''},          {false}, {'logical'},      {false}, {'Do not bother reading k-space itself.  Ex: only headers.'}}, ...
+         {{'ReadNoiseAdj'},           {''},          {false}, {'logical'},      {false}, {'Attempt to read noise adjust scans (bitmask=0x02000000).  Data will be attached as a .noise field to each kspace output.'}}, ...
+         {{'ReadPMU'},                {''},          {false}, {'logical'},      {true},  {'Reads in the embedded PMU times and waveforms from the meas.dat header.  Usually requires gated sequences.'}}, ...
+         {{'ReadRelSliceNumber'},     {''},          {false}, {'logical'},      {true},  {'Read relative slice number from header.  Necessary to sort 2D acquisitions.'}}, ...
+         {{'ReadSequenceTime'},       {''},          {false}, {'logical'},      {false}, {'Sequence time (10us resolution) from the channel header. Only the first channel will be read.'}}, ...
+         {{'ReadTimeStamp'},          {''},          {false}, {'logical'},      {false}, {'Time stamps (2.5ms) since midnight corresponding to KSpace lines.'}}, ...
+         {{'ReadPMUTimeStamp'},       {''},          {false}, {'logical'},      {false}, {'2.5ms since last trigger (one-to-one with lines)'}}, ...
+         {{'ReadTimeSinceLastRF'},    {''},          {false}, {'logical'},      {false}, {'Time stamps (2.5ms) since last RF (one-to-one with lines).'}}, ...
+         {{'ReadIceProgramParam'},    {''},          {false}, {'logical'},      {false}, {'Read the free ice program para associated with each readout MDH (24 uint16 per readout + 4 so called reserved uint16).'}}, ...
+         {{'ReadSVector'},            {''},          {false}, {'logical'},      {false}, {'Read the slice vector from each scan line'}}, ...
+         {{'ReadQuaternion'},         {''},          {false}, {'logical'},      {false}, {'Read the quaternion from each scan line'}}, ...
+         {{'ReadWiPMemBlock'},        {''},          {false}, {'logical'},      {true},  {'Extract WiPMemBlock from header.  User must provide return variable in var arg out.'}}, ...
+         {{'ReadSliceArray'},         {''},          {false}, {'logical'},      {true},  {'Extract SliceArray from ASCCONV portion of header.'}}, ...
+         {{'ReadFileInfo'},           {''},          {false}, {'logical'},      {true},  {'If you have jGetFileInfo in your path, it will be called to read and parse portions of the text header.'}}, ...
+         {{'UseMexInsertion'},        {''},          {false}, {'logical'},      {false}, {'Use copy_column_a2b_single_complex mex program to speed up insertion of lines into kspace memory.  Requires having compiled copy_column_a2b_single_complex.'}}, ...
+         {{'ResetFFTScale'},          {''},          {false}, {'logical'},      {false}, {'Reset scale for each coil (read from FFT Correction Factors) to one.'}}, ...
+         {{'ShiftDCToMatrixCenter'},  {''},          {false}, {'logical'},      {false}, {'Shifts output k-space such that DC occurs at n/2+1 for all dimensions.'}}, ...
+         {{'Silent'},                 {''},          {false}, {'logical'},      {false}, {'Turns off all GUI and output messages.  User must supply all necessary arguments.'}}, ...
+         {{'CollapseSeg'},            {''},          {false}, {'logical'},      {false}, {'Ignore the SEG dimension, effectively collapsing along that dimension.'}}, ...
+         {{'SwapSegAndEco'},          {''},          {false}, {'logical'},      {false}, {'Swap incoming segment and echo indices.  Hack to permit reading of HIFU navigators encoded with SEG indices.'}}, ...
+      };
+
+   for iUserInput = 1:length(userInputValues)
+      for iField = 1:length(userInputFieldNames)
+         UserInputDefault(iUserInput).(userInputFieldNames{iField}{1}) = userInputValues{iUserInput}{iField}{1};
+      end     
+   end
+
+end
+
+% =============================================================================
+function UserInputDefault = derive_user_input_default_fieldname(UserInputDefault)
+% -----------------------------------------------------------------------------
+% Derives fieldnames to used later for User Input struct.  
+% Names based on variation of possible user inputs.
+%    ex.  User input 'ReadSomething'  becomes field name 'readSomething'
+% -----------------------------------------------------------------------------
+
+   % Setup fieldNames
+   for iUserInput = 1:length(UserInputDefault)
+      if isempty(UserInputDefault(iUserInput).fieldName)
+         fieldName = UserInputDefault(iUserInput).varArgIn;
+         fieldName(1) = lower(fieldName(1));
+         UserInputDefault(iUserInput).fieldName = fieldName;
+      end
+   end
+
+end
+
+% =============================================================================
+function User = convert_user_input_default_to_struct(UserInputDefault)
+% -----------------------------------------------------------------------------
+% Set up user input structure with default values.
+% -----------------------------------------------------------------------------
+
+   for iUserInput = 1:length(UserInputDefault)
+      if strcmp(UserInputDefault(iUserInput).type, 'logical')
+         User.(UserInputDefault(iUserInput).fieldName) = UserInputDefault(iUserInput).defaultValue;
+      else
+         User.(UserInputDefault(iUserInput).fieldName) = uint64(hex2dec(UserInputDefault(iUserInput).defaultValue));
+      end
+      if strcmp(UserInputDefault(iUserInput).varArgIn(1:4),'Read')
+         fieldName = ['found',UserInputDefault(iUserInput).varArgIn(5:end)];
+      else
+         fieldName = ['found',UserInputDefault(iUserInput).varArgIn];
+      end
+      User.(fieldName) = false;
+   end
+
+end
+
+% =============================================================================
+function filenameIn = check_filename_input(filenameIn, nArgIn, Control)
+% -----------------------------------------------------------------------------
+% Check filenameIn and query if empty.
+% -----------------------------------------------------------------------------
+
+   if nArgIn == 0
+      if ~Control.User.noGui
+         filenameIn = uigetfile('*.dat','Select File to Read');
+      else
+         if ~Control.User.silent
+            textMessage = 'Must provide file name to read';
+            display_message(Control.User.noGui,'ERROR',textMessage);
+         end
+         return
+      end
+   end
+
+end
+
+% =============================================================================
+function filenameInExists = check_filename_exists(filenameIn, Control)
+% -----------------------------------------------------------------------------
+% Check for file existence.
+% -----------------------------------------------------------------------------
+   filenameInExists = (exist(filenameIn, 'file') == 2);
+   if ~filenameInExists
+      if ~Control.User.silent
+         textMessage = ['File does not exist: ' filenameIn];
+         display_message(Control.User.noGui,'ERROR',textMessage,'Error');
+      end
+   end
+end
+
+% =============================================================================
+function Control = modify_with_inputs_outputs(optionsIn, Control, UserInputDefault)
+% -----------------------------------------------------------------------------
+% Adjust controls based on user inputs/outputs
+% -----------------------------------------------------------------------------
+
+   Control.nArgOut = 0;
+
+   iOption = 1;
+   while iOption <= length(optionsIn)
+
+      flagFoundMatch = false;
+      for iUserInput = 1:length(UserInputDefault)
+         flagFoundMatch = flagFoundMatch || strcmpi(optionsIn{iOption},UserInputDefault(iUserInput).varArgIn);
+         if flagFoundMatch
+            break;
+         end
+      end
+      if flagFoundMatch
+         fieldName = UserInputDefault(iUserInput).fieldName;
+         fieldNameFound = ['found',UserInputDefault(iUserInput).varArgIn];
+         if strcmp(UserInputDefault(iUserInput).type, 'logical')
+            Control.User.(fieldName) = true;
+            if UserInputDefault(iUserInput).isArgOut
+               fieldName = ['iArgOut',UserInputDefault(iUserInput).varArgIn(5:end)];
+               Control.nArgOut = Control.nArgOut + 1;
+               Control.User.(fieldName) = Control.nArgOut;
+            end
+         end
+         if strcmp(UserInputDefault(iUserInput).type, 'hex2dec')
+            iOption = iOption + 1;
+            Control.User.(fieldName) = uint64(hex2dec(optionsIn{iOption}));
+            Control.User.(fieldNameFound) = true;
+         end
+      end
+      iOption = iOption + 1;
+   end % while over options
+
+end
+
+% =============================================================================
+function goodToGo = are_inputs_and_outputs_consistent(nOptionsIn, nArgOutMain, Control)
+% -----------------------------------------------------------------------------
+% Check for consistentcy between argin and argout when a given argin might
+%    lead to more data in the output.
+% -----------------------------------------------------------------------------
+
+   goodToGo = true;
+   if (nOptionsIn > 0) && ((nArgOutMain-1) ~= Control.nArgOut)
+      goodToGo = false;
+      if ~Control.User.silent
+         textMessage = 'You must have an equal number of kSpace output variables for all the kSpace you expect to read.'; 
+         display_message(Control.User.noGui,'ERROR',textMessage,'Insufficient Outputs');
+      end
+   end
+
+   if Control.User.shiftDCToMatrixCenter && (Control.User.readTimeStamp || Control.User.readPMUTimeStamp || Control.User.readTimeSinceLastRF || Control.User.readSequenceTime)
+      goodToGo = false;
+      if ~Control.User.silent
+         textMessage = 'You cannot turn on ShiftDCToMatrixCenter when reading time stamps';
+         display_message(Control.User.noGui,'ERROR',textMessage,'Insufficient Outputs');
+      end
+   end
+
+end
+
+% =============================================================================
+function Control = get_controls_from_user_input(filenameIn, optionsIn, numArgIn, numArgOut)
+% -----------------------------------------------------------------------------
+% Setup main control structure using user inputs.
+% -----------------------------------------------------------------------------
+
+   global mdhBitFlag
+
+   Control.GUI.hWaitBar = []; % Initialize to blank
+
+   nOptionsIn = numArgIn - 1;
+
+   UserInputDefault = define_user_input_default_struct_array;
+   UserInputDefault = derive_user_input_default_fieldname(UserInputDefault);
+
+   Control.User = convert_user_input_default_to_struct(UserInputDefault);
+   Control = modify_with_inputs_outputs(optionsIn, Control, UserInputDefault);
+
+   Control.File.In.name = check_filename_input(filenameIn, nargin, Control);
+   if ~check_filename_exists(Control.File.In.name, Control)
+      Control = [];
+      return
+   end
+
+   if ~are_inputs_and_outputs_consistent(nOptionsIn, numArgOut, Control)
+      Control = [];
+      return 
+   end
+
+   % Speed up insertion operations with a mex
+   if Control.User.useMexInsertion
+      Control.User.useMexInsertion = (exist('copy_column_a2b_single_complex') == 3);
+   end
+
+   % Adjust masks for scanevalinfomask run
+   if Control.User.scanEvalInfoMaskOnly
+      Control.User.foundKeepBitMask = true;
+      Control.User.foundDropBitMask = false;
+      Control.User.keepMatchAllBits = false;
+      Control.User.keepBitMask = uint64(hex2dec('fffffffffffff'));
+      Control.User.dropBitMask = uint64(0);
+      Control.User.logicKeepOnly = true;
+      Control.User.logicDropOnly = false;
+   end
+
+   % Address user provided keep/drop flags
+   if Control.User.foundDropBitMask || Control.User.foundKeepBitMask
+      if Control.User.foundDropBitMask && Control.User.foundKeepBitMask
+         mdhBitFlag.bDropEIM.f = Control.User.dropBitMask;
+         mdhBitFlag.bKeepEIM.f = Control.User.keepBitMask;
+      elseif Control.User.foundDropBitMask
+         mdhBitFlag.bDropEIM.f = Control.User.dropBitMask;
+      else 
+         mdhBitFlag.bKeepEIM.f = Control.User.keepBitMask;
+      end
+   end
+
+   % Check logic flags
+   if ((Control.User.logicKeepOnly + Control.User.logicDropOnly) > 1)
+      Control = [];
+      return 
+   end
+   if Control.User.keepMatchAllBits
+      mdhBitFlag.bKeepEIM.l = 'bitandeq';
+   else
+      mdhBitFlag.bKeepEIM.l = 'bitandnz';
+   end
+   if Control.User.dropMatchAllBits
+      mdhBitFlag.bDropEIM.l = 'bitandeq';
+   else
+      mdhBitFlag.bDropEIM.l = 'bitandnz';
+   end
+   if Control.User.logicKeepOnly || Control.User.logicDropOnly
+      if Control.User.logicKeepOnly
+         mdhBitFlag.bDropEIM.l = 'alwaysfalse';
+      else % Control.User.logicDropOnly
+         mdhBitFlag.bKeepEIM.l = 'alwaystrue';
+      end
+   end
+   if ~Control.User.silent
+      print_setup_status(Control.File.In.name, UserInputDefault, Control);
+   end
+
+end
+
+% =============================================================================
+function [isVE11, MrParcRaidFileHeader, MrParcRaidFileCell] = is_ve11_file(Control, fid)
+% -----------------------------------------------------------------------------
+% Check that this is a VE11 file.
+% -----------------------------------------------------------------------------
+
+   MrParcRaidFileHeader = [];
+   MrParcRaidFileCell = {};
+   isVE11 = 0;
+   FileHeader.totalSize  = fread(fid,1,'uint32=>uint32');
+   FileHeader.nMeas = fread(fid,1,'uint32=>uint32');
+   if not(and(FileHeader.totalSize < 10000, FileHeader.nMeas <= 64))
+      if ~Control.User.silent
+         display_message(Control.User.noGui,'ERROR',['Appears to be VB data: ' Control.File.In.name],'Error');
+      end
+      return 
+   else
+      MrParcRaidFileHeader = FileHeader;
+      isVE11 = 1;
+   end
+
+   % Extract measurement parameters
+   for iMeas = 1:MrParcRaidFileHeader.nMeas
+
+      MrParcRaidFileCell{iMeas}.measID = fread(fid,1,'uint32=>uint32');
+      MrParcRaidFileCell{iMeas}.fileID = fread(fid,1,'uint32=>uint32');
+      MrParcRaidFileCell{iMeas}.offsetInFile = fread(fid,1,'uint64=>uint64');
+      MrParcRaidFileCell{iMeas}.totalSize = fread(fid,1,'uint64=>uint64');
+      MrParcRaidFileCell{iMeas}.patName = fread(fid,64,'uchar=>char');
+      MrParcRaidFileCell{iMeas}.protName = fread(fid,64,'uchar=>char');
+      MrParcRaidFileCell{iMeas}.Control = Control;
+
+   end
+
+end
+
+% =============================================================================
+function [Control, MrParcRaidFileCell, Dim, CoilSelectMap, TextHeader, ...
+          CoilSelectMeasMap, RelativeSliceNumber, WiPMemBlock, SliceArray, MeasYapsAsc] = ...
+             parse_meas_text_header(Control,fid,MrParcRaidFileCell,iMeas)
+% -----------------------------------------------------------------------------
+% Parse the text portion of the measurement to extract required dimensions,
+%    scaling factors, slice ordering, etc.
+% -----------------------------------------------------------------------------
+
+   % Skip to start of this measurement
+   fseek(fid,MrParcRaidFileCell{iMeas}.offsetInFile,'bof');
+
+   % TextHeader extraction
+   Dim.dMeasHeaderSize = fread(fid,1,'int32');
+   Dim.ullMeasHeaderSize = uint64(Dim.dMeasHeaderSize);
+   textHeader = fread(fid,Dim.dMeasHeaderSize-4,'uchar=>char');
+   textHeader = textHeader';
+   TextHeader.complete = textHeader;
+   clear textHeader;
+
+   findThisStart = 'MeasYaps';
+   findThisEnd = 'Phoenix';
+   pStart = strfind(TextHeader.complete,findThisStart) + length(findThisStart) + 5;
+   pEnd = strfind(TextHeader.complete,findThisEnd) - 3;
+   % Vida has >1 occurence of Phoenix which must now be differentiated
+   if length(pEnd) > 1
+      indexGood = find((pEnd-pStart) > 0);
+      pEnd = pEnd(indexGood(1));
+   end
+   TextHeader.measYapsAscConv = TextHeader.complete(pStart:pEnd);
+
+   %             {{'address in Siemens XProt',       'which header',   'regular expression to find value',                                'conversion', default}} 
+   searchCells = {{'Dim.Raw.readoutOversampleFactor' 'complete'        '.*flReadoutOSFactor[^\s]*\s*{\s*<Precision>\s*[0-9]*\s*([0-9.]+)' 'str2num'    2.0} ...
+                  {'Dim.Raw.nCha'                    'measYapsAscConv' '\[0\]\.asList\[([0-9]+)\]\.lRxChannelConnected\s*=\s*'            'length'        } ...
+                  {'Dim.Recon.nFourierPartitions'    'complete'        '.*iNoOfFourierPartitions[^\s]*\s*{\s*([0-9.]+)'                   'str2num'      1} ...
+                  {'Dim.Recon.phaseEncodeFTLength'   'complete'        '.*iPEFTLength[^\s]*\s*{\s*([0-9.]+)'                              'str2num'       } ...
+                  {'Dim.Recon.partitionFTLength'     'complete'        '.*i3DFTLength[^\s]*\s*{\s*([0-9.]+)'                              'str2num'       } ...
+                  {'Control.File.scanDimension'      'measYapsAscConv' 'sKSpace.ucDimension[^=]+=\s*([0-9]+)\s*'                          'str2num'       } ...
+                  {'Dim.Recon.nLin'                  'complete'        'iPEFTLen[^{}]+{\s*([0-9]+)\s*}'                                   'str2double'    } ...
+                  {'Control.File.measUIDString'      'complete'        'MeasUID[^{}]+{\s*([0-9]+)\s*}'                                    'string'        } ...
+                  {'Dim.Recon.nPar'                  'measYapsAscConv' 'sKSpace.lPartitions[^=]+=\s*([0-9]+)\s*'                          'str2num'       } ...
+                  {'Dim.Recon.nSlc'                  'measYapsAscConv' 'sSliceArray.lSize[^=]+=\s*([0-9]+)\s*'                            'str2num'       } ...
+                  {'Dim.Raw.nEco'                    'measYapsAscConv' 'lContrasts\s*=\s*([0-9]+)\s*'                                     'str2num'      1} ...
+                  {'Dim.Raw.nSet'                    'measYapsAscConv' 'lSets\s*=\s*([0-9]+)\s*'                                          'str2num'      1} ...
+                  {'Dim.Raw.nAcq'                    'measYapsAscConv' 'lAverages\s*=\s*([0-9]+)\s*'                                      'str2num'      1} ...
+                  {'Dim.Raw.nRep'                    'measYapsAscConv' 'lRepetitions\s*=\s*([0-9]+)\s*'                                   'str2num'      1} ...
+                  {'Dim.Raw.nPhs'                    'measYapsAscConv' 'sPhysioImaging.lPhases\s*=\s*([0-9]+)\s*'                         'str2num'      1} ...
+                  {'Control.File.epiFactor'          'measYapsAscConv' 'sFastImaging.lEPIFactor\s*=\s*([0-9]+)\s*'                        'str2num'       } ...
+                  {'Control.File.turboFactor'        'measYapsAscConv' 'sFastImaging.lTurboFactor\s*=\s*([0-9]+)\s*'                      'str2num'      1} ...
+                  {'Dim.Raw.nMaxRxChannels'          'complete'        '.*iMaxNoOfRxChannels[^\s]*\s*{\s*([0-9]+)'                        'str2num'    128} ...
+                  {'Dim.Raw.nPhaseCor'               'complete'        '.*lNoOfPhaseCorrScans[^\s]*\s*{\s*([0-9]+)'                       'str2num'      0} ...
+                  {'Dim.Recon.nFourierColumns'       'complete'        '.*iNoOfFourierColumns[^\s]*\s*{\s*([0-9]+)'                       'str2num'       } ...
+                  {'Dim.Recon.nFourierLines'         'complete'        '.*NoOfFourierLines[^\s]*\s*{\s*([0-9.]+)'                         'str2num'       } ...
+                  {'Dim.Recon.readoutFTLength'       'complete'        '.*iRoFTLength[^\s]*\s*{\s*([0-9.]+)'                              'str2num'       }};
+   for searchCell = searchCells
+      flagHasDefault = length(searchCell{1}) > 4;
+      address = strsplit(searchCell{1}{1},'.');
+      searchField = searchCell{1}{2};
+      searchString = searchCell{1}{3};
+      conversion = searchCell{1}{4};
+      if flagHasDefault
+         defaultValue = searchCell{1}{5};
+      end
+      searchResult= regexp(TextHeader.(searchField),searchString,'tokens');
+      if ~isempty(searchResult)
+         if strcmp(conversion,'str2num')
+            searchValue = str2num(searchResult{1}{1});
+         elseif strcmp(conversion,'string')
+            searchValue = searchResult{1}{1};
+         elseif strcmp(conversion,'length')
+            searchValue = length(searchResult);
+         elseif strcmp(conversion,'str2double')
+            searchValue = str2double(searchResult{1}{1});
+         else
+            Control = [];
+            MrParcRaidFileCell = [];
+            Dim = [];
+            CoilSelectMap = [];
+            CoilSelectMeasMap = {};
+            RelativeSliceNumber = [];
+            WiPMemBlock = [];
+            SliceArray = [];
+            MeasYapsAsc = [];
+          return
+         end
+      elseif flagHasDefault
+         searchValue = defaultValue;
+      else
+         continue;
+      end
+      if strcmp(address{1},'Dim')
+         Dim.(address{2}).(address{3}) = searchValue;
+      end
+      if strcmp(address{1},'Control')
+         MrParcRaidFileCell{iMeas}.Control.(address{2}).(address{3}) = searchValue;
+      end
+   end
+
+   if MrParcRaidFileCell{iMeas}.Control.File.scanDimension == 4
+      MrParcRaidFileCell{iMeas}.Control.File.is3D = true;
+   else
+      MrParcRaidFileCell{iMeas}.Control.File.is3D = false;
+   end
+
+%   findThis = 'AdjustSeq%/AdjCoilSensSeq';
+%   p = strfind(TextHeader.measYapsAscConv,findThis) + length(findThis);
+%   if Dim.Raw.nCha > 1 && ~isempty(p)
+%      Dim.Raw.nCha = Dim.Raw.nCha-1;
+%   end
+
+   if Dim.Raw.nMaxRxChannels < Dim.Raw.nCha
+      Dim.Raw.nCha = Dim.Raw.nMaxRxChannels;
+   end
+
+   if MrParcRaidFileCell{iMeas}.Control.File.turboFactor > 1
+      Dim.Raw.nPhaseCor = 1;
+   end
+   if MrParcRaidFileCell{iMeas}.Control.File.epiFactor > 1
+      Dim.Raw.nPhaseCor = 1;
+   end
+
+   Dim.Recon.nNonOSColumns = round(Dim.Recon.nFourierColumns/Dim.Raw.readoutOversampleFactor);
+
+   if Dim.Recon.nFourierPartitions == 1
+      Dim.Recon.partitionFTLength = 1;
+   end
+
+   %% Raw Data Correction Factors (NOTE: CURRENTLY false!!!!)
+   clear CoilSelectMap;
+   findThis = '{\s*{\s*{\s*"[^"]+"[^\n]+';
+   % Vida started introducing extra carriage returns which requires fancier processing
+   pStart = regexp(TextHeader.complete, findThis, 'start');
+   %allCoilsInHeaderCell = regexp(TextHeader.complete, findThis, 'match');
+   %if ~isempty(allCoilsInHeaderCell)
+   if length(pStart) > 0
+      pEnd = regexp(TextHeader.complete(pStart(1):end), '}[\n\s]*}[\n\s]*}', 'end');
+      if length(pEnd) > 0
+         %allCoilsInHeaderCell = allCoilsInHeaderCell{1};
+         allCoilsInHeaderCell = TextHeader.complete(pStart(1):pStart(1)+pEnd(1)+1);
+         findThis = '{\s*{\s*"(?<name>[^"]+)"\s*}\s*{\s*(?<fft>[\d\.]+)\s*}\s*{\s*(?<re>[\d\.-]+)\s*}\s*{\s*(?<im>[\d\.-]+)\s*}\s*}';
+         CoilStructArray = regexp(allCoilsInHeaderCell, findThis,'names');
+         if length(CoilStructArray) == Dim.Raw.nCha
+            for c=1:Dim.Raw.nCha
+               tName = CoilStructArray(c).name;
+               CoilSelect.fftScale = sscanf(CoilStructArray(c).fft,'%f');
+               CoilSelect.rawDataCorrectionFactor = complex(sscanf(CoilStructArray(c).re,'%f'),sscanf(CoilStructArray(c).im,'%f'));
+               CoilSelect.txtOrder = c-1;
+               CoilSelectMap.(tName) = CoilSelect;
+               clear CoilSelect
+            end
+         end
+         if (length(fieldnames(CoilSelectMap)) ~= Dim.Raw.nCha) && Control.User.applyRawDataCorrection
+            if ~Control.User.silent
+               display_message(Control.User.noGui,'ERROR','Non-unique channel names in CoilSelect','Error');
+            end
+            fclose(fid);
+            Control = [];
+            MrParcRaidFileCell = [];
+            Dim = [];
+            CoilSelectMap = [];
+            CoilSelectMeasMap = {};
+            RelativeSliceNumber = [];
+            WiPMemBlock = [];
+            SliceArray = [];
+            MeasYapsAsc = [];
+            return
+         end
+      else
+         keyboard
+      end
+   end
+
+   RelativeSliceNumber = [];
+   if Control.User.readRelSliceNumber
+
+      findThis = sprintf('ParamLong."relSliceNumber">[\\s\\n]*{');
+      pStart = regexp(TextHeader.complete,findThis);
+      if ~isempty(pStart)
+         pStart = pStart(1) + strfind(TextHeader.complete(pStart(1):pStart(1) + length(findThis)+20),'{');
+         pStart = pStart(1);
+         pEnd = strfind(TextHeader.complete(pStart(1):end),'}');
+         if ~isempty(pEnd)
+            pEnd = pStart + pEnd(1) - 2;
+            findThis = '([^0-9\s]*[\-0-9]+)(\s+)';
+            relSliceNumCell = regexp(TextHeader.complete(pStart:pEnd),findThis,'tokens');
+            if ~isempty(relSliceNumCell)
+               relativeSliceNumber = zeros(1,length(relSliceNumCell));
+               for i=1:length(relSliceNumCell)
+                  relativeSliceNumber(i) = str2double(relSliceNumCell{i}{1});
+               end
+               RelativeSliceNumber{iMeas} = relativeSliceNumber;
+               Control.User.foundRelSliceNumber = true;
+            end
+         end
+      end
+   end
+
+   % Meas Yaps AscConv parsing
+   %MeasYapsAsc = parse_meas_yaps_ascconv(TextHeader.measYapsAscConv);
+   MeasYapsAsc = [];
+
+   % SliceArray
+   if Control.User.readSliceArray
+      findThis = sprintf('sSliceArray\\.lSize\\s*=\\s*([0-9]+)\\s*');
+      lSizeCell = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+      if ~isempty(lSizeCell)
+         Control.User.foundSliceArray = true;
+         nSliceLocal = str2num(lSizeCell{1}{1});
+         SliceArray.Thickness = zeros(1,nSliceLocal);
+         SliceArray.PhaseFOV = zeros(1,nSliceLocal);
+         SliceArray.ReadoutFOV = zeros(1,nSliceLocal);
+         SliceArray.Position = zeros(3,nSliceLocal);
+         SliceArray.Normal = zeros(3,nSliceLocal);
+         DirectionStr = {{'dSag'}, {'dCor'}, {'dTra'}};
+         for iSlice=1:nSliceLocal
+            findThis = sprintf('sSliceArray\\.asSlice\\[%d\\]\\.dThickness\\s*=\\s*([.0-9]+)\\s*', iSlice-1);
+            dThicknessCell = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+            if ~isempty(dThicknessCell)
+               SliceArray.Thickness(iSlice) = str2num(dThicknessCell{1}{1});
+            end 
+            findThis = sprintf('sSliceArray\\.asSlice\\[%d\\]\\.dPhaseFOV\\s*=\\s*([.0-9]+)\\s*', iSlice-1);
+            dPhaseFOVCell = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+            if ~isempty(dPhaseFOVCell)
+               SliceArray.PhaseFOV(iSlice) = str2num(dPhaseFOVCell{1}{1});
+            end 
+            findThis = sprintf('sSliceArray\\.asSlice\\[%d\\]\\.dReadoutFOV\\s*=\\s*([.0-9]+)\\s*', iSlice-1);
+            dReadoutFOVCell = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+            if ~isempty(dReadoutFOVCell)
+               SliceArray.ReadoutFOV(iSlice) = str2num(dReadoutFOVCell{1}{1});
+            end 
+            for iDir=1:3
+               findThis = sprintf('sSliceArray\\.asSlice\\[%d\\]\\.sPosition\\.%s\\s*=\\s*([^\\s]+)\\s*',iSlice,DirectionStr{iDir}{1});
+               dPosition = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+               if ~isempty(dPosition)
+                  SliceArray.Position(iDir,iSlice) = str2num(dPosition{1}{1});
+               end
+               findThis = sprintf('sSliceArray\\.asSlice\\[%d\\]\\.sNormal\\.%s\\s*=\\s*([^\\s]+)\\s*',iSlice,DirectionStr{iDir}{1});
+               dNormal = regexp(TextHeader.measYapsAscConv, findThis, 'tokens');
+               if ~isempty(dNormal)
+                  SliceArray.Normal(iDir,iSlice) = str2num(dNormal{1}{1});
+               end
+            end
+         end
+      end
+   else
+      SliceArray = [];
+   end
+
+   % WiPMemBlock
+   if Control.User.readWiPMemBlock
+
+      findThis = sprintf('ParamMap."sWiPMemBlock">[\\s\\n]*{');
+      pStartWiPMemBlock = regexp(TextHeader.complete, findThis, 'ignorecase');
+      WiPMemBlock.adRes = [];
+      WiPMemBlock.tFree = [];
+      WiPMemBlock.adFree = [];
+      WiPMemBlock.lCSatBW = [];
+      WiPMemBlock.alFree = [];
+      if ~isempty(pStartWiPMemBlock)
+         pStartWiPMemBlock = pStartWiPMemBlock(1) + strfind(TextHeader.complete(pStartWiPMemBlock(1):pStartWiPMemBlock(1) + length(findThis)+20),'{');
+         pStartWiPMemBlock = pStartWiPMemBlock(1);
+         findThis = sprintf('<ParamLong."alFree">[\\s\\n]*{');
+         pStartAlFree = regexp(TextHeader.complete(pStartWiPMemBlock:end), findThis, 'ignorecase');
+         if ~isempty(pStartAlFree)
+            pStartAlFree = pStartWiPMemBlock + pStartAlFree(1); 
+            pStartAlFree = pStartAlFree + strfind(TextHeader.complete(pStartAlFree(1):pStartAlFree(1) + length(findThis)+20),'{');
+            pStartAlFree = pStartAlFree(1);
+            pEnd_alFree = strfind(TextHeader.complete(pStartAlFree(1):end),'}');
+            if ~isempty(pEnd_alFree)
+               pEnd_alFree = pStartAlFree + pEnd_alFree(1) - 2;
+               % Skip any precision/default stuff
+               pLessThan = strfind(TextHeader.complete(pStartAlFree:pEnd_alFree),'<');
+               if ~isempty(pLessThan)
+                  pStartAlFree = pLessThan(end) + pStartAlFree;
+                  pStartAlFree = pStartAlFree + strfind(TextHeader.complete(pStartAlFree:pEnd_alFree),sprintf('\n'));
+                  pStartAlFree = pStartAlFree(1);
+               end
+               alFreeCell = regexp(TextHeader.complete(pStartAlFree:pEnd_alFree),'([\-0-9]+)\s+','tokens');
+               if ~isempty(alFreeCell)
+                  Control.User.foundWiPMemBlock = true;
+                  WiPMemBlock.alFree = zeros(1,length(alFreeCell),'int32');
+                  for i_alFree=1:length(alFreeCell)
+                     WiPMemBlock.alFree(i_alFree) = int32(str2num(alFreeCell{i_alFree}{1}));
+                  end
+               end
+            end
+         end
+         findThis = sprintf('<ParamLong."lCSatBW">[\\s\\n]*{');
+         pStartLCSatBW = regexp(TextHeader.complete(pStartWiPMemBlock:end), findThis, 'ignorecase');
+         if ~isempty(pStartLCSatBW)
+            pStartLCSatBW = pStartWiPMemBlock + pStartLCSatBW(1); 
+            pStartLCSatBW = pStartLCSatBW + strfind(TextHeader.complete(pStartLCSatBW(1):pStartLCSatBW(1) + length(findThis)+20),'{');
+            pStartLCSatBW = pStartLCSatBW(1);
+            pEnd_lCSatBW = strfind(TextHeader.complete(pStartLCSatBW(1):end),'}');
+            if ~isempty(pEnd_lCSatBW)
+               pEnd_lCSatBW = pStartLCSatBW + pEnd_lCSatBW(1) - 2;
+               % Skip any precision/default stuff
+               pLessThan = strfind(TextHeader.complete(pStartLCSatBW:pEnd_lCSatBW),'<');
+               if ~isempty(pLessThan)
+                  pStartLCSatBW = pLessThan(end) + pStartLCSatBW;
+                  pStartLCSatBW = pStartLCSatBW + strfind(TextHeader.complete(pStartLCSatBW:pEnd_lCSatBW),sprintf('\n'));
+                  pStartLCSatBW = pStartLCSatBW(1);
+               end
+               lCSatBWCell = regexp(TextHeader.complete(pStartLCSatBW:pEnd_lCSatBW),'([\-0-9]+)\s+','tokens');
+               if ~isempty(lCSatBWCell)
+                  WiPMemBlock.lCSatBW = zeros(1,length(lCSatBWCell),'int32');
+                  Control.User.foundWiPMemBlock = true;
+                  for i_lCSatBW=1:length(lCSatBWCell)
+                     WiPMemBlock.lCSatBW(i_lCSatBW) = int32(str2num(lCSatBWCell{i_lCSatBW}{1}));
+                  end
+               end
+            end
+         end
+         findThis = sprintf('<ParamDouble."adFree">[\\s\\n]*{');
+         pStartAdFree = regexp(TextHeader.complete(pStartWiPMemBlock:end), findThis, 'ignorecase');
+         if ~isempty(pStartAdFree)
+            pStartAdFree = pStartWiPMemBlock + pStartAdFree(1); 
+            pStartAdFree = pStartAdFree + strfind(TextHeader.complete(pStartAdFree(1):pStartAdFree(1) + length(findThis)+20),'{');
+            pStartAdFree = pStartAdFree(1);
+            pEnd_adFree = strfind(TextHeader.complete(pStartAdFree(1):end),'}');
+            if ~isempty(pEnd_adFree)
+               pEnd_adFree = pStartAdFree + pEnd_adFree(1) - 2;
+               % Skip any precision/default stuff
+               pLessThan = strfind(TextHeader.complete(pStartAdFree:pEnd_adFree),'<');
+               if ~isempty(pLessThan)
+                  pStartAdFree = pLessThan(end) + pStartAdFree;
+                  pStartAdFree = pStartAdFree + strfind(TextHeader.complete(pStartAdFree:pEnd_adFree),sprintf('\n'));
+                  pStartAdFree = pStartAdFree(1);
+               end
+               adFreeCell = regexp(TextHeader.complete(pStartAdFree:pEnd_adFree),'([\-0-9\.]+)\s+','tokens');
+               if ~isempty(adFreeCell)
+                  Control.User.foundWiPMemBlock = true;
+                  WiPMemBlock.adFree = zeros(1,length(adFreeCell));
+                  for i_adFree=1:length(adFreeCell)
+                     WiPMemBlock.adFree(i_adFree) = str2num(adFreeCell{i_adFree}{1});
+                  end
+               end
+            end
+         end
+         findThis = sprintf('<ParamDouble."adRes">[\\s\\n]*{');
+         pStartAdRes = regexp(TextHeader.complete(pStartWiPMemBlock:end), findThis, 'ignorecase');
+         if ~isempty(pStartAdRes)
+            pStartAdRes = pStartWiPMemBlock + pStartAdRes(1); 
+            pStartAdRes = pStartAdRes + strfind(TextHeader.complete(pStartAdRes(1):pStartAdRes(1) + length(findThis)+20),'{');
+            pStartAdRes = pStartAdRes(1);
+            pEnd_adRes = strfind(TextHeader.complete(pStartAdRes(1):end),'}');
+            if ~isempty(pEnd_adRes)
+               pEnd_adRes = pStartAdRes + pEnd_adRes(1) - 2;
+               % Skip any precision/default stuff
+               pLessThan = strfind(TextHeader.complete(pStartAdRes:pEnd_adRes),'<');
+               if ~isempty(pLessThan)
+                  pStartAdRes = pLessThan(end) + pStartAdRes;
+                  pStartAdRes = pStartAdRes + strfind(TextHeader.complete(pStartAdRes:pEnd_adRes),sprintf('\n'));
+                  pStartAdRes = pStartAdRes(1);
+               end
+               adResCell = regexp(TextHeader.complete(pStartAdRes:pEnd_adRes),'([\-0-9\.]+)\s+','tokens');
+               if ~isempty(adResCell)
+                  Control.User.foundWiPMemBlock = true;
+                  WiPMemBlock.adRes = zeros(1,length(adResCell));
+                  for i_adRes=1:length(adResCell)
+                     WiPMemBlock.adRes(i_adRes) = str2num(adResCell{i_adRes}{1});
+                  end
+               end
+            end
+         end
+         findThis = sprintf('<ParamString."tFree">[\\s\\n]*{');
+         pStartTFree = regexp(TextHeader.complete(pStartWiPMemBlock:end), findThis, 'ignorecase');
+         if ~isempty(pStartTFree)
+            pStartTFree = pStartWiPMemBlock + pStartTFree(1); 
+            pStartTFree = pStartTFree + strfind(TextHeader.complete(pStartTFree(1):pStartTFree(1) + length(findThis)+20),'{');
+            pStartTFree = pStartTFree(1);
+            pEnd_tFree = strfind(TextHeader.complete(pStartTFree(1):end),'}');
+            if ~isempty(pEnd_tFree)
+               pEnd_tFree = pStartTFree + pEnd_tFree(1) - 2;
+               % Skip any precision/default stuff
+               pLessThan = strfind(TextHeader.complete(pStartTFree:pEnd_tFree),'<');
+               if ~isempty(pLessThan)
+                  pStartTFree = pLessThan(end) + pStartTFree;
+                  pStartTFree = pStartTFree + strfind(TextHeader.complete(pStartTFree:pEnd_tFree),sprintf('\n'));
+                  pStartTFree = pStartTFree(1);
+               end
+               tFreeCell = regexp(TextHeader.complete(pStartTFree:pEnd_tFree),'"([^"])"\s+','tokens');
+               if ~isempty(tFreeCell)
+                  Control.User.foundWiPMemBlock = true;
+                  WiPMemBlock.tFree = zeros(1,length(tFreeCell));
+                  for i_tFree=1:length(tFreeCell)
+                     WiPMemBlock.tFree(i_tFree) = str2num(tFreeCell{i_tFree}{1});
+                  end
+               end
+            end
+         end
+      end % if wipmemblock found
+   else
+       WiPMemBlock = [];
+   end
+
+   %% FFT Correction Factors
+   CoilSelectMeasMap = {};
+   for c=1:Dim.Raw.nCha
+      CoilSelectMeas.textOrder = c-1;
+      findThis = 'asList\[';
+      findThis = sprintf('%s%d',findThis,c-1);
+      findThis = [findThis,'\]\.sCoilElementID.tCoilID\s*=\s*"([^"]+)"\s*'];
+      p = regexp(TextHeader.measYapsAscConv,findThis,'tokens');
+      CoilSelectMeas.tCoilID = p{1}{1};
+      findThis = 'asList\[';
+      findThis = sprintf('%s%d',findThis,c-1);
+      findThis = [findThis,'\]\.sCoilElementID.tElement\s*=\s*"([^"]+)"\s*'];
+      p = regexp(TextHeader.measYapsAscConv,findThis,'tokens');
+      CoilSelectMeas.tElement = p{1}{1};
+      findThis = 'asList\[';
+      findThis = sprintf('%s%d',findThis,c-1);
+      findThis = [findThis,'\]\.lRxChannelConnected\s*=\s*([0-9.]+)\s*'];
+      p = regexp(TextHeader.measYapsAscConv,findThis,'tokens');
+      CoilSelectMeas.lRxChannel = str2num(p{1}{1});
+      findThis = 'asList\[';
+      findThis = sprintf('%s%d',findThis,c-1);
+      findThis = [findThis,'\]\.lADCChannelConnected\s*=\s*([0-9.]+)\s*'];
+      p = regexp(TextHeader.measYapsAscConv,findThis,'tokens');
+      lADCChannel = str2num(p{1}{1});
+      if MrParcRaidFileCell{iMeas}.Control.User.resetFFTScale
+         CoilSelectMeas.flFFTCorrectionFactor = single(1.0); 
+      else
+         findThis = 'aFFT_SCALE\[';
+         findThis = sprintf('%s%d',findThis,c-1);
+         findThis = [findThis,'\]\.flFactor\s*=\s*([0-9.]+)\s*'];
+         p = regexp(TextHeader.measYapsAscConv,findThis,'tokens');
+         CoilSelectMeas.flFFTCorrectionFactor = single(str2double(p{1}{1}));
+      end
+      %keySet = sprintf('k%06d',lADCChannel);
+      %CoilSelectMeasMap.(keySet) = CoilSelectMeas;
+      CoilSelectMeasMap{lADCChannel} = CoilSelectMeas;
+      clear CoilSelectMeas;
+   end
+
+   %clear keySet valueSet TextHeader.measYapsAscConv;
+   clear keySet valueSet;
+
+   if Dim.Recon.nFourierLines == Dim.Recon.nLin && Dim.Recon.nFourierPartitions == Dim.Recon.nPar
+      MrParcRaidFileCell{iMeas}.Control.User.noFillToFullFourier = true;
+   end
+
+   if ~MrParcRaidFileCell{iMeas}.Control.File.is3D
+      Dim.Recon.nPar = Dim.Recon.nFourierPartitions;
+   end
+
+   %clear TextHeader; % TextHeader is now returned
+
+   if Dim.Recon.nFourierLines > Dim.Recon.nLin
+       Dim.Recon.nLin = Dim.Recon.nFourierLines;
+   end
+
+   if Dim.Recon.nFourierPartitions > Dim.Recon.nPar
+       Dim.Recon.nPar = Dim.Recon.nFourierPartitions;
+   end
+
+end
+
+% =============================================================================
+function textMessage = print_setup_status(filenameIn, UserInputDefault, Control)
+% -----------------------------------------------------------------------------
+% Send text to the user based on GUI or print statement.
+% -----------------------------------------------------------------------------
+   textMessage = sprintf('Filename=%s', filenameIn);
+   for iArg = 1:length(UserInputDefault)
+      if strcmp(UserInputDefault(iArg).type, 'logical')
+         textMessage = sprintf('%s\n%s=%d', ...
+                               textMessage, ...
+                               UserInputDefault(iArg).varArgIn, ...
+                               Control.User.(UserInputDefault(iArg).fieldName));
+      else
+         textMessage = sprintf('%s\n%s=''%08x'' (hex string)', ...
+                               textMessage, ...
+                               UserInputDefault(iArg).varArgIn, ...
+                               Control.User.(UserInputDefault(iArg).fieldName));
+      end
+   end
+   display_message(Control.User.noGui,'WAIT',textMessage,'File Will Be Read With These Parameters');
+end
+
+% =============================================================================
+function textMessage = print_available_options(UserInputDefault)
+% -----------------------------------------------------------------------------
+% Based on default inputs, indicate to user what is possible.
+% -----------------------------------------------------------------------------
+   iGroup = 1;
+   stepGroup = 8;
+   for iArg = 1:stepGroup:length(UserInputDefault)
+      if iArg == 1
+         textMessage = sprintf('[kSpace, Other] = fast_read_ve11(fileName, ''option1'', ''option2'', ...');
+         textMessage = sprintf('%s\n\nfileName is the name of a meas.dat to read and',textMessage);
+         textMessage = sprintf('%s\n\nOptions are as follows:', textMessage);
+      else
+         textMessage = sprintf('Options are as follows:');
+      end
+      for jArg=iArg:min((iArg+stepGroup),length(UserInputDefault))
+         textMessage = sprintf('%s\n\n''%s'': (default', ...
+                               textMessage, ...
+                               UserInputDefault(jArg).varArgIn);
+         switch UserInputDefault(jArg).type
+            case 'logical'
+               if UserInputDefault(jArg).defaultValue
+                  textMessage = sprintf('%s true)', textMessage);
+               else
+                  textMessage = sprintf('%s false)', textMessage);
+               end
+            case 'hex2dec'
+               textMessage = sprintf('%s ''%08x'' (hex string))', textMessage, UserInputDefault(jArg).defaultValue);
+            otherwise
+               textMessage = sprintf('%s unknown)', textMessage);
+         end
+         textMessage = sprintf('%s %s', textMessage, UserInputDefault(jArg).description);
+      end
+      if usejava('jvm') && ~feature('ShowFigureWindows')
+         display(textMessage);
+      else
+         msgbox(textMessage, sprintf('Usage (Page %d)', iGroup));
+      end
+      iGroup = iGroup + 1;
+   end
+end
+
+% =============================================================================
+function MdhBlockMeta = append_to_mdhblockmeta(iBlock, iBlockMeta, MdhBlock, varargin)
+% -----------------------------------------------------------------------------
+% Append to existing MdhBlockMeta list.
+% -----------------------------------------------------------------------------
+   copyField = {'isSyncData', 'isAcqEnd', 'keepScan', 'dmaLength', 'nScan', 'nSamplesInScan', 'nChannelUsed'};
+   %if length(varargin) > 0
+   if ~isempty(varargin)
+      MdhBlockMeta = varargin{1};
+   end
+   MdhBlockMeta(iBlockMeta).nBlock = 1;
+   MdhBlockMeta(iBlockMeta).iBlock(MdhBlockMeta(iBlockMeta).nBlock) = iBlock;
+   for iField=1:length(copyField)
+      MdhBlockMeta(iBlockMeta).(copyField{iField}) = MdhBlock(iBlock).(copyField{iField});
+   end
+end
+
+% =============================================================================
+function set_global_mdh_parameters(filenameIn)
+% -----------------------------------------------------------------------------
+% Handle some global parameters.
+% -----------------------------------------------------------------------------
+
+   global MDH_SCANSIZE MDH_CHANSIZE MDH_PMUSIZE MAX_BYTES_PER_FREAD
+   global mdhColumns mdhBitFlag
+   global MDH_MAP_EIM
+   global index_keys
+   global MDH_HEX2DEC_FFFFFF
+
+   MDH_HEX2DEC_FFFFFF = hex2dec('FFFFFF');
+
+   index_keys = {'indexLIN','indexACQ','indexSLC','indexPAR','indexECO','indexPHS','indexREP','indexSET','indexSEG', 'indexIDA', 'indexIDB', 'indexIDC', 'indexIDD', 'indexIDE'};
+
+   % EvalInfoMask
+   MDH_EIM_ACQEND            = 2^uint64(0);  % last scan 
+   MDH_EIM_RTFEEDBACK        = 2^uint64(1);  % Realtime feedback scan
+   MDH_EIM_HPFEEDBACK        = 2^uint64(2);  % High perfomance feedback scan
+   MDH_EIM_ONLINE            = 2^uint64(3);  % processing should be done online
+   MDH_EIM_OFFLINE           = 2^uint64(4);  % processing should be done offline
+   MDH_EIM_SYNCDATA          = 2^uint64(5);  % readout contains synchroneous data
+   MDH_EIM_LASTSCANINCONCAT  = 2^uint64(8);  % Flag for last scan in concatination
+   MDH_EIM_RAWDATACORRECTION = 2^uint64(10); % Correct the rawadata with the rawdata correction factor
+   MDH_EIM_LASTSCANINMEAS    = 2^uint64(11); % Flag for last scan in measurement
+   MDH_EIM_SCANSCALEFACTOR   = 2^uint64(12); % Flag for scan specific additional scale factor
+   MDH_EIM_2NDHADAMARPSE     = 2^uint64(13); % 2nd RF exitation of HADAMAR
+   MDH_EIM_REFPHASESTABSCAN  = 2^uint64(14); % reference phase stabilization scan
+   MDH_EIM_PHASESTABSCAN     = 2^uint64(15); % phase stabilization scan
+   MDH_EIM_D3FFT             = 2^uint64(16); % execute 3D FFT
+   MDH_EIM_SIGNREV           = 2^uint64(17); % sign reversal
+   MDH_EIM_PHASEFFT          = 2^uint64(18); % execute phase fft
+   MDH_EIM_SWAPPED           = 2^uint64(19); % swapped phase/readout direction
+   MDH_EIM_POSTSHAREDLINE    = 2^uint64(20); % shared line
+   MDH_EIM_PHASCOR           = 2^uint64(21); % phase correction data
+   MDH_EIM_PATREFSCAN        = 2^uint64(22); % additonal scan for PAT reference line/partition
+   MDH_EIM_PATREFANDIMASCAN  = 2^uint64(23); % additonal scan for PAT reference line/partition that is also used as image scan
+   MDH_EIM_REFLECT           = 2^uint64(24); % reflect line
+   MDH_EIM_NOISEADJSCAN      = 2^uint64(25); % noise adjust scan 
+   MDH_EIM_SHARENOW          = 2^uint64(26); % all lines are acquired from the actual and previous e.g. phases
+   MDH_EIM_LASTMEASUREDLINE  = 2^uint64(27); % indicates that the current line is the last measured line of all succeeding e.g. phases
+   MDH_EIM_FIRSTSCANINSLICE  = 2^uint64(28); % indicates first scan in slice (needed for time stamps)
+   MDH_EIM_LASTSCANINSLICE   = 2^uint64(29); % indicates  last scan in slice (needed for time stamps)
+   MDH_EIM_TREFFECTIVEBEGIN  = 2^uint64(30); % indicates the begin time stamp for TReff (triggered measurement)
+   MDH_EIM_TREFFECTIVEEND    = 2^uint64(31); % indicates the   end time stamp for TReff (triggered measurement)
+   MDH_EIM_MDS_REF_POSITION          = 2^uint64(32); % indicates the reference position for move during scan images (must be set once per slice/partition in MDS mode)
+   MDH_EIM_SLC_AVERAGED              = 2^uint64(33); % indicates avveraged slice for slice partial averaging scheme
+   MDH_EIM_TAGFLAG1                  = 2^uint64(34); % adjust scan 
+   MDH_EIM_CT_NORMALIZE              = 2^uint64(35); % Marks scans used to calcate correction maps for TimCT-Prescan normalize
+   MDH_EIM_SCAN_FIRST                = 2^uint64(36); % Marks the first scan of a particar map
+   MDH_EIM_SCAN_LAST                 = 2^uint64(37); % Marks the last scan of a particar map
+   MDH_EIM_FIRST_SCAN_IN_BLADE       = 2^uint64(40); % Marks the first line of a blade
+   MDH_EIM_LAST_SCAN_IN_BLADE        = 2^uint64(41); % Marks the last line of a blade
+   MDH_EIM_LAST_BLADE_IN_TR          = 2^uint64(42); % Set for all lines of the last BLADE in each TR interval
+   MDH_EIM_PACE                      = 2^uint64(44); % Distinguishes PACE scans from non PACE scans.
+   MDH_EIM_RETRO_LASTPHASE           = 2^uint64(45); % Marks the last phase in a heartbeat
+   MDH_EIM_RETRO_ENDOFMEAS           = 2^uint64(46); % Marks an ADC at the end of the measurement
+   MDH_EIM_RETRO_REPEATTHISHEARTBEAT = 2^uint64(47); % Repeat the current heartbeat when this bit is found
+   MDH_EIM_RETRO_REPEATPREVHEARTBEAT = 2^uint64(48); % Repeat the previous heartbeat when this bit is found
+   MDH_EIM_RETRO_ABORTSCANNOW        = 2^uint64(49); % Just abort everything
+   MDH_EIM_RETRO_LASTHEARTBEAT       = 2^uint64(50); % This adc is from the last heartbeat (a dummy)
+   MDH_EIM_RETRO_DUMMYSCAN           = 2^uint64(51); % This adc is just a dummy scan, throw it away
+   MDH_EIM_RETRO_ARRDETDISABLED      = 2^uint64(52); % Disable all arrhythmia detection when this bit is found
+
+   % Construct the map
+   keySet = {};
+   valueSet = uint64([]);
+   iKey = 1;
+   whosStruct = whos();
+   variableNames = {whosStruct.name};
+   for iVar=1:length(variableNames)
+      if length(variableNames{iVar}) < 8
+         continue
+      end
+      if strcmp(variableNames{iVar}(1:8),'MDH_EIM_')
+         keySet{iKey} = variableNames{iVar}(8:end);
+         valueSet(iKey) = eval(variableNames{iVar});
+         iKey = iKey + 1;
+      end
+   end
+   MDH_MAP_EIM = containers.Map(keySet,valueSet);
+
+   MDH_DEFAULT_EIM_DROP = MDH_EIM_RTFEEDBACK + ...
+                         MDH_EIM_HPFEEDBACK + ...
+                         MDH_EIM_PATREFSCAN + ...
+                         MDH_EIM_NOISEADJSCAN + ...
+                         MDH_EIM_PHASCOR + ...
+                         MDH_EIM_REFPHASESTABSCAN + ...
+                         MDH_EIM_RETRO_DUMMYSCAN; %+ ...
+                         %MDH_EIM_RAWDATACORRECTION;
+   MDH_DEFAULT_EIM_KEEP = bitcmp(MDH_DEFAULT_EIM_DROP,'uint64');
+
+   % Some default sizes
+   MDH_SCANSIZE = uint64(192);
+   MDH_CHANSIZE = uint64(32);
+   MDH_PMUSIZE = uint64(60);
+   MAX_BYTES_PER_FREAD = 2^uint64(27);
+   fileSpecs = dir(filenameIn);
+   MAX_BYTES_PER_FREAD = min(MAX_BYTES_PER_FREAD,fileSpecs.bytes); % Constrain to file size
+
+   % Columns within the binary scan lines where
+   %    particular data is found along with how
+   %    it should be converted.
+   mdhColumns.scan.dmaLength.c = [1 4];
+   mdhColumns.scan.dmaLength.t = 'uint32';
+   mdhColumns.scan.timeStamp.c = [13 16];
+   mdhColumns.scan.timeStamp.t = 'uint32';
+   mdhColumns.scan.pMUTimeStamp.c = [17 20];
+   mdhColumns.scan.pMUTimeStamp.t = 'uint32';
+   mdhColumns.scan.evalMask.c = [41 48];
+   mdhColumns.scan.evalMask.t = 'uint64';
+   mdhColumns.scan.nSamplesInScan.c = [49 50];
+   mdhColumns.scan.nSamplesInScan.t = 'uint16';
+   mdhColumns.scan.nChannelUsed.c = [51 52];
+   mdhColumns.scan.nChannelUsed.t = 'uint16';
+   mdhColumns.scan.indexLIN.c = [53 54];
+   mdhColumns.scan.indexLIN.t = 'uint16';
+   mdhColumns.scan.indexACQ.c = [55 56];
+   mdhColumns.scan.indexACQ.t = 'uint16';
+   mdhColumns.scan.indexSLC.c = [57 58];
+   mdhColumns.scan.indexSLC.t = 'uint16';
+   mdhColumns.scan.indexPAR.c = [59 60];
+   mdhColumns.scan.indexPAR.t = 'uint16';
+   mdhColumns.scan.indexECO.c = [61 62];
+   mdhColumns.scan.indexECO.t = 'uint16';
+   mdhColumns.scan.indexPHS.c = [63 64];
+   mdhColumns.scan.indexPHS.t = 'uint16';
+   mdhColumns.scan.indexREP.c = [65 66];
+   mdhColumns.scan.indexREP.t = 'uint16';
+   mdhColumns.scan.indexSET.c = [67 68];
+   mdhColumns.scan.indexSET.t = 'uint16';
+   mdhColumns.scan.indexSEG.c = [69 70];
+   mdhColumns.scan.indexSEG.t = 'uint16';
+   mdhColumns.scan.indexIDA.c = [71 72];
+   mdhColumns.scan.indexIDA.t = 'uint16';
+   mdhColumns.scan.indexIDB.c = [73 74];
+   mdhColumns.scan.indexIDB.t = 'uint16';
+   mdhColumns.scan.indexIDC.c = [75 76];
+   mdhColumns.scan.indexIDC.t = 'uint16';
+   mdhColumns.scan.indexIDD.c = [77 78];
+   mdhColumns.scan.indexIDD.t = 'uint16';
+   mdhColumns.scan.indexIDE.c = [79 80];
+   mdhColumns.scan.indexIDE.t = 'uint16';
+   mdhColumns.scan.cutOffDataPre.c = [81 82];
+   mdhColumns.scan.cutOffDataPre.t = 'uint16';
+   mdhColumns.scan.cutOffDataPost.c = [83 84];
+   mdhColumns.scan.cutOffDataPost.t = 'uint16';
+   mdhColumns.scan.timeSinceLastRF.c = [93 96];
+   mdhColumns.scan.timeSinceLastRF.t = 'uint32';
+   mdhColumns.scan.kSpaceCentreLineNo.c = [97 98];
+   mdhColumns.scan.kSpaceCentreLineNo.t = 'uint16';
+   mdhColumns.scan.kSpaceCentrePartitionNo.c = [99 100];
+   mdhColumns.scan.kSpaceCentrePartitionNo.t = 'uint16';
+   mdhColumns.scan.sVector.c = [101 112];
+   mdhColumns.scan.sVector.t = 'single';
+   mdhColumns.scan.quaternion.c = [113 128];
+   mdhColumns.scan.quaternion.t = 'single';
+   mdhColumns.scan.iceProgramPara.c = [129 184];
+   mdhColumns.scan.iceProgramPara.t = 'uint16';
+
+   mdhColumns.chan.sizeChanInBytes.c = [1 4];
+   mdhColumns.chan.sizeChanInBytes.t = 'uint32';
+   mdhColumns.chan.sequenceTime.c = [17 20];
+   mdhColumns.chan.sequenceTime.t = 'uint32';
+   mdhColumns.chan.channelID.c = [25 26];
+   mdhColumns.chan.channelID.t = 'uint16';
+
+   mdhColumns.pmu.timeStamp.c = [1 8];
+   mdhColumns.pmu.timeStamp.t = 'uint32';
+   mdhColumns.pmu.counter.c = [9 12];
+   mdhColumns.pmu.counter.t = 'uint32';
+   mdhColumns.pmu.duration.c = [13 16];
+   mdhColumns.pmu.duration.t = 'uint32';
+   mdhColumns.pmu.data.c = [17 0];
+   mdhColumns.pmu.data.t = 'uint32';
+
+   mdhBitFlag.isNoiseAdj.s = 'evalMask';
+   mdhBitFlag.isNoiseAdj.f = MDH_EIM_NOISEADJSCAN;
+   mdhBitFlag.isNoiseAdj.l = 'bitandeq';
+   mdhBitFlag.isPatRefScan.s = 'evalMask';
+   mdhBitFlag.isPatRefScan.f = MDH_EIM_PATREFSCAN;
+   mdhBitFlag.isPatRefScan.l = 'bitandeq';
+   mdhBitFlag.isPhaseCor.s = 'evalMask';
+   mdhBitFlag.isPhaseCor.f = MDH_EIM_PHASCOR;
+   mdhBitFlag.isPhaseCor.l = 'bitandeq';
+   mdhBitFlag.isRTFeedback.s = 'evalMask';
+   mdhBitFlag.isRTFeedback.f = MDH_EIM_RTFEEDBACK;
+   mdhBitFlag.isRTFeedback.l = 'bitandeq';
+   mdhBitFlag.isAcqEnd.s = 'evalMask';
+   mdhBitFlag.isAcqEnd.f = MDH_EIM_ACQEND;
+   mdhBitFlag.isAcqEnd.l = 'bitandeq';
+   mdhBitFlag.isReflect.s = 'evalMask';
+   mdhBitFlag.isReflect.f = MDH_EIM_REFLECT;
+   mdhBitFlag.isReflect.l = 'bitandeq';
+   mdhBitFlag.isRawDataCorrection.s = 'evalMask';
+   mdhBitFlag.isRawDataCorrection.f = MDH_EIM_RAWDATACORRECTION;
+   mdhBitFlag.isRawDataCorrection.l = 'bitandeq';
+   mdhBitFlag.isSyncData.s = 'evalMask';
+   mdhBitFlag.isSyncData.f = MDH_EIM_SYNCDATA;
+   mdhBitFlag.isSyncData.l = 'bitandeq';
+   mdhBitFlag.bKeepEIM.s = 'evalMask';
+   mdhBitFlag.bKeepEIM.f = MDH_DEFAULT_EIM_KEEP;
+   mdhBitFlag.bKeepEIM.l = 'bitandnz';
+   mdhBitFlag.bDropEIM.s = 'evalMask';
+   mdhBitFlag.bDropEIM.f = MDH_DEFAULT_EIM_DROP;
+   mdhBitFlag.bDropEIM.l = 'bitandnz';
+
+end
+
+% =============================================================================
+function display_eval_mask(evalMaskArray,iMeas)
+% -----------------------------------------------------------------------------
+% Display eval mask array data, converting to human readable form
+% -----------------------------------------------------------------------------
+
+   global MDH_MAP_EIM
+
+   textMessage = 'dma, nRead, nChan, eimint, eimhex, eimtext';
+
+   bitsEIM = values(MDH_MAP_EIM);
+   namesEIM = keys(MDH_MAP_EIM);
+   [~,indexSort] = sort(cell2mat(bitsEIM));
+   u64Zero = uint64(0);
+   tableData = {};
+   for iEval =1:length(evalMaskArray)
+      textMessage = sprintf('%s\n%s', textMessage, evalMaskArray{iEval});
+      evalMaskData = uint64(sscanf(evalMaskArray{iEval}, '%d, %d, %d, %lu'));
+      for iData=1:length(evalMaskData)
+         tableData{iEval,iData} = evalMaskData(iData);
+      end
+      tableData{iEval,length(evalMaskData)+1} = sprintf('0x%013X', evalMaskData(end));
+      iMatch = 0;
+      for iFlag=1:length(bitsEIM)
+         iSort = indexSort(iFlag);
+         if bitand(evalMaskData(end),bitsEIM{iSort},'uint64') > u64Zero
+            if iMatch < 1 
+               namesStr = sprintf('%s(0x%013X)',namesEIM{iSort}, bitsEIM{iSort});
+            else
+               namesStr = sprintf('%s+%s(0x%013X)', namesStr, namesEIM{iSort}, bitsEIM{iSort});
+            end
+            iMatch = iMatch + 1;
+         end
+      end
+      if iMatch > 0
+         textMessage = sprintf('%s, %s', textMessage, namesStr);
+         tableData{iEval,length(evalMaskData)+2} = namesStr;
+      else
+         tableData{iEval,length(evalMaskData)+2} = '';
+      end
+   end
+   if usejava('jvm') && ~feature('ShowFigureWindows')
+      textMessage = sprintf('Unique Eval1Mask Combinations for Meas %d\n%s', iMeas, textMessage);
+      display(textMessage);
+   else
+      uf = figure('Name', sprintf('Unique Eval1Mask Combinations for Meas %d', iMeas), ...
+                  'NumberTitle', 'off', ...
+                  'MenuBar', 'none', ...
+                  'ToolBar', 'none', ...
+                  'Position', [200 200 840 270], ...
+                  'Visible', 'off');
+      t = uitable(uf);
+      t.Data = tableData;
+      t.ColumnName = {'dma','nRead','nChan','eimval','eimhex','eimText'};
+      t.Position = [20, 20, 800, 230];
+      t.ColumnWidth = {'auto','auto','auto','auto',100,900};
+      set(uf,'Visible','on');
+   end
+
+end
+
+% =============================================================================
+function MdhParam = extract_single_mdh_parameter(mdhBuffer, paramType, nameToExtract)
+% -----------------------------------------------------------------------------
+% Extract a parameter from the uint8 array based on input description.
+% -----------------------------------------------------------------------------
+
+   global mdhColumns 
+
+   columns = mdhColumns.(paramType).(nameToExtract).c;
+   temp = mdhBuffer(columns(1):columns(2),:);
+   MdhParam = typecast(temp(:),mdhColumns.(paramType).(nameToExtract).t);
+
+   return
+
+end
+
+% =============================================================================
+function MdhParam = extract_mdh_parameters(mdhBuffer, paramType, namesToExtract)
+% -----------------------------------------------------------------------------
+% Extract an array of parameters, similar to extract_single_mdh_parameter.
+% -----------------------------------------------------------------------------
+
+   global mdhColumns 
+
+   switch nargin
+      case 3
+         fieldNames = namesToExtract;
+      case 2
+         fieldNames = fieldnames(mdhColumns.(paramType));
+      otherwise
+         paramType = 'scan';
+         fieldNames = fieldnames(mdhColumns.(paramType));
+   end
+
+   for iField = 1:length(fieldNames)
+      columns = mdhColumns.(paramType).(fieldNames{iField}).c;
+      if columns(2) == 0 % PMU data goes to the end of the buffer
+         columns(2) = length(mdhBuffer);
+      end
+      temp = mdhBuffer(columns(1):columns(2),:);
+      MdhParam.(fieldNames{iField}) = typecast(temp(:),mdhColumns.(paramType).(fieldNames{iField}).t);
+   end
+
+   return
+
+end
+
+% =============================================================================
+function MdhBitFlags = extract_mdh_bitflags(mdhBuffer, flagsToExtract)
+% -----------------------------------------------------------------------------
+% Pull bitflags from the MDH evalMasks
+% -----------------------------------------------------------------------------
+
+   global mdhBitFlag
+   
+   if nargin == 1
+      fieldNames = fieldnames(mdhBitFlag);
+   else
+      fieldNames = flagsToExtract;
+   end
+
+   MdhBitFlags.evalMask = extract_single_mdh_parameter(mdhBuffer, 'scan', 'evalMask');
+   for iField = 1:length(fieldNames)
+      evalMask = mdhBitFlag.(fieldNames{iField}).s;
+      bitFlag = mdhBitFlag.(fieldNames{iField}).f;
+      logicType = mdhBitFlag.(fieldNames{iField}).l;
+      switch logicType
+         case 'bitandeq'
+            MdhBitFlags.(fieldNames{iField}) = bitand(MdhBitFlags.(evalMask), bitFlag, 'uint64') == bitFlag;
+         case 'bitandnz'
+            MdhBitFlags.(fieldNames{iField}) = bitand(MdhBitFlags.(evalMask), bitFlag, 'uint64')  > uint64(0);
+         case 'alwaystrue'
+            MdhBitFlags.(fieldNames{iField}) = ones(size(MdhBitFlags.(evalMask))) > 0;
+         case 'alwaysfalse'
+            MdhBitFlags.(fieldNames{iField}) = ones(size(MdhBitFlags.(evalMask))) < 1;
+         otherwise % same as bitandeq
+            MdhBitFlags.(fieldNames{iField}) = bitand(MdhBitFlags.(evalMask), bitFlag, 'uint64') == bitFlag;
+      end % switch
+   end
+
+   return;
+
+end
+
+% =============================================================================
+function MdhBlock = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam)
+% -----------------------------------------------------------------------------
+% Set up MdhBlock structure
+% -----------------------------------------------------------------------------
+
+   MdhBlock.offsetInFile = offsetInFile;
+   MdhBlock.dmaLength = dmaLength;
+   MdhBlock.nScan = uint64(0); % Initialize with zero value
+   MdhBlock.isSyncData = MdhBitFlags.isSyncData;
+   MdhBlock.isAcqEnd = MdhBitFlags.isAcqEnd;
+   MdhBlock.nSamplesInScan = uint64(MdhParam.nSamplesInScan);
+   MdhBlock.nChannelUsed = MdhParam.nChannelUsed;
+   MdhBlock.sizeFirstChanInBytes = sizeFirstChanInBytes;
+   MdhBlock.keepScan = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+
+end
+
+% =============================================================================
+function dimOut = max_from_mdh_param(dimIn, nChannelUsed, dimNames, MdhParam, indices)
+% -----------------------------------------------------------------------------
+% Compute output dimensions
+% -----------------------------------------------------------------------------
+   dimOut = dimIn;
+   dimOut(1) = max(dimIn(1), nChannelUsed-1);
+   for iDim=2:numel(dimNames)
+      indexName = strcat('index',dimNames{iDim});
+      dimOut(iDim) = max(dimIn(iDim), max(MdhParam.(indexName)(indices(:))));
+   end
+   return
+end
+
+% =============================================================================
+function rankOut = rank_from_mdh_param(rankIn, dimNames, MdhParam, nChannels, indices)
+% -----------------------------------------------------------------------------
+% Determine which dimensions vary most rapidly based on mdh values
+% -----------------------------------------------------------------------------
+   rankOut = rankIn;
+   rankOut(1) = rankIn(1) + uint64(numel(indices(2:end))) * uint64(nChannels);
+   for iDim=2:numel(dimNames)
+      indexName = strcat('index',dimNames{iDim});
+      diffMask = MdhParam.(indexName)(indices(2:end)) ~= MdhParam.(indexName)(indices(1:end-1));
+      rankOut(iDim) = rankIn(iDim) + uint64(sum(diffMask,1));
+   end
+   return
+end
+
+% =============================================================================
+function rankOut = rank_from_index_prev(rankIn, dimNames, MdhParam, nChannels, index, indexPrev)
+% -----------------------------------------------------------------------------
+% Determine column order based on indices in the mdh
+% -----------------------------------------------------------------------------
+   rankOut = rankIn;
+   rankOut(1) = rankOut(1) + uint64(nChannels);
+   for iDim=2:numel(dimNames)
+      indexName = strcat('index',dimNames{iDim});
+      diffMask = indexPrev.(indexName) ~= MdhParam.(indexName)(index);
+      rankOut(iDim) = rankIn(iDim) + uint64(sum(diffMask,1));
+   end
+   return
+end
+
+% =============================================================================
+function indexPrev = set_index_prev(dimNames, MdhParam, index)
+% -----------------------------------------------------------------------------
+% Bookeeping for tracking what dimensions vary most rapidly
+% -----------------------------------------------------------------------------
+   for iDim=2:numel(dimNames)
+      indexName = strcat('index',dimNames{iDim});
+      indexPrev.(indexName) = MdhParam.(indexName)(index);
+   end
+   return
+end
+ 
+% =============================================================================
+function output = compute_cumulative_product(input)
+% -----------------------------------------------------------------------------
+% Compute the cumulative product for an input array.  Apparently before matlab
+%    2013, cumprod only supports floating cumprod and I need one for integers!
+%
+% output = compute_cumulative_product(input) returns array of same type and
+%    structure as input with cumulative product computed from first to last
+%    element
+%
+% HISTORY:   05 Dec 2014. J. Roberts. roberts@ucair.med.utah.edu
+%            UCAIR, Dept Radiology, School of Med, U of U, SLC, UT
+% -----------------------------------------------------------------------------
+
+   output = ones(size(input),class(input(1)));
+   output(1) = input(1);
+   for p=2:numel(input)
+      output(p) = output(p-1) * input(p);
+   end
+
+end
+
+% =============================================================================
+function output = compute_product(input)
+% -----------------------------------------------------------------------------
+% Compute the product for an input array.  Apparently before matlab 2013, prod
+%    only supports floating prod and I need one for integers!
+%
+% output = compute_product(input) returns array of same type and structure
+%                                     as input with product 
+%                                     computed from first to last element
+%
+% HISTORY:   05 Dec 2014. J. Roberts. roberts@ucair.med.utah.edu
+%            UCAIR, Dept Radiology, School of Med, U of U, SLC, UT
+% -----------------------------------------------------------------------------
+
+   output = input(1);
+   for p=2:numel(input)
+      output = output * input(p);
+   end
+
+end
+
+% =============================================================================
+function display_message(noGui,typeMessage,textMessage,textExtra)
+% -----------------------------------------------------------------------------
+
+   if noGui
+      disp(textMessage);
+   else
+      if strcmp(typeMessage,'WARNING')
+         warndlg(textMessage);
+      elseif strcmp(typeMessage,'ERROR')
+         errordlg(textMessage,textExtra);
+      else
+         uiwait(msgbox(textMessage, textExtra, 'modal'));
+      end
+   end
+
+end
+
+% =============================================================================
+function [evalMaskArray, sizeAllScansInBytes, sizeChanInBytes, MdhBlock, nBlockSYNCDATA, ...
+          nBlockACQEND, nBlockScan, blockNScan, nScanInMeas, dmaLengthScan, ...
+          nSamplesInScan] = ...
+             chunk_into_equal_line_length_blocks2(fid,MrParcRaidFileCell, iMeas, Dim, Control)
+% -----------------------------------------------------------------------------
+% -----------------------------------------------------------------------------
+   global MDH_SCANSIZE MAX_BYTES_PER_FREAD
+   global MDH_HEX2DEC_FFFFFF
+
+   if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+      mdhParamToExtract = {'dmaLength','nSamplesInScan','nChannelUsed','evalMask'};
+   else
+      mdhParamToExtract = {'dmaLength','nSamplesInScan','nChannelUsed'};
+   end
+   evalMaskArray = {};
+   sizeAllScansInBytes = MrParcRaidFileCell{iMeas}.totalSize - Dim.ullMeasHeaderSize;
+   fseek(fid,MrParcRaidFileCell{iMeas}.offsetInFile + Dim.ullMeasHeaderSize,'bof');
+   % Read the first line to get the DMA length and line type
+   mdhScan = fread(fid,MDH_SCANSIZE+4,'uchar=>uchar');
+   MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+   if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+      evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+      if isempty(find(strcmp(evalMaskArray,evalStr)))
+         evalMaskArray{length(evalMaskArray)+1} = evalStr;
+      end
+   end
+   MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+   bHasACQEND = MdhBitFlags.isAcqEnd;
+   bKeepScan = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+   dmaLength = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes used for dmaLength
+   sizeFirstChanInBytes = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+   iRelativePosition = uint64(1);
+   iBlock = 1;
+   offsetInFile = MrParcRaidFileCell{iMeas}.offsetInFile + Dim.ullMeasHeaderSize;
+   % NOTE: We make a very simple assumption that the same number of
+   %    samples per scan will hold for scans of the same dmaLength
+   % Similarly for the number of channels (which mean nothing in SYNCDATA scans)
+   MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+   while ((iRelativePosition < sizeAllScansInBytes) && ~bHasACQEND)
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         textMessage = 'Pass 1 of 3: Parsing blocks';
+         waitbar(double(iRelativePosition)/double(sizeAllScansInBytes), Control.GUI.hWaitBar, textMessage);
+      end
+      fseek(fid,MdhBlock(iBlock).offsetInFile + MdhBlock(iBlock).nScan * dmaLength,'bof');
+      bytesRemaining = sizeAllScansInBytes-iRelativePosition+uint64(1);
+      if dmaLength < 2048
+         nScanToRead=uint64(177);  % We don't usually get a lot short lines
+      else
+         nScanToRead = max(idivide(MAX_BYTES_PER_FREAD, dmaLength,'fix'),uint64(1));
+      end   
+      %if iBlock > 20
+      %   indexKeep = find([MdhBlock.keepScan]);
+      %   if length(indexKeep) > 0
+      %      nScanToRead = min(nScanToRead, median([MdhBlock(indexKeep).nScan]));
+      %   end
+      %end
+      bytesToRead = nScanToRead*dmaLength;
+      if (bytesToRead > bytesRemaining)
+         nScanToRead = idivide(bytesRemaining,dmaLength,'fix');
+         if nScanToRead < 1
+            [mdhScan, readCount] = fread(fid,MDH_SCANSIZE+4,'uchar=>uchar');
+            MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+            if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+               evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+               if isempty(find(strcmp(evalMaskArray,evalStr)))
+                  evalMaskArray{length(evalMaskArray)+1} = evalStr;
+               end
+            end
+            MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+            bKeepScanNext = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+            dmaLengthNext = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes used by dmaLength
+            if readCount > MDH_SCANSIZE
+               sizeFirstChanInBytesNext = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+            else
+               sizeFirstChanInBytesNext = uint64(0);
+            end
+            nScanToRead = uint64(1);
+            if (dmaLengthNext == dmaLength) && (bKeepScan == bKeepScanNext)
+               error_message
+            else
+               iBlock = iBlock + 1;
+               offsetInFile = MdhBlock(iBlock-1).offsetInFile + MdhBlock(iBlock-1).nScan * dmaLength;
+               dmaLength = dmaLengthNext;
+               bKeepScan = bKeepScanNext;
+               sizeFirstChanInBytes = sizeFirstChanInBytesNext;
+               MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+               fseek(fid,MdhBlock(iBlock).offsetInFile + MdhBlock(iBlock).nScan * dmaLength,'bof');
+            end
+         end
+      end
+      bytesToRead = nScanToRead*dmaLength;
+      [blockOfScans, readCount] = fread(fid,bytesToRead,'uchar=>uchar');
+      if MdhBlock(iBlock).isAcqEnd && (readCount < bytesToRead)
+         dmaLength = readCount / nScanToRead;
+      end
+      iStart = int64(1);
+      while (uint64(iStart) + MDH_SCANSIZE - 1) <= readCount
+         mdhScan = blockOfScans(uint64(iStart):min(uint64(iStart)+MDH_SCANSIZE+4-1,readCount));
+         MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+         if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+            evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+            if isempty(find(strcmp(evalMaskArray,evalStr)))
+               evalMaskArray{length(evalMaskArray)+1} = evalStr;
+            end
+         end
+         MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+         bKeepScanNext = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+         dmaLengthNext = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes for dmaLength
+         if length(mdhScan) > MDH_SCANSIZE
+            sizeFirstChanInBytesNext = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+         else
+            sizeFirstChanInBytesNext = uint64(0);
+         end
+         bHasACQEND = bHasACQEND || MdhBlock(iBlock).isAcqEnd;
+         if (dmaLengthNext == dmaLength) && (bKeepScanNext == bKeepScan)
+            MdhBlock(iBlock).nScan = MdhBlock(iBlock).nScan + 1;
+            iRelativePosition = iRelativePosition + dmaLength;
+         else
+            iBlock = iBlock + 1;
+            %if (iBlock > 8423)
+            %   keyboard
+            %end
+            offsetInFile =MdhBlock(iBlock-1).offsetInFile + MdhBlock(iBlock-1).nScan * dmaLength;
+            flagDMALengthChange = dmaLength ~= dmaLengthNext;
+            dmaLength = dmaLengthNext;
+            bKeepScan = bKeepScanNext;
+            sizeFirstChanInBytes = sizeFirstChanInBytesNext;
+            MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+            %if flagDMALengthChange % No need to reread a chunk if dma length has not changed
+            %   break;
+            %end
+            iStart = iStart - int64(dmaLength); % backup and re-read this data into a the new block
+         end
+         if bHasACQEND
+            break;
+         end
+         iStart = iStart + int64(dmaLength);
+      end % for over block of scans with same dmalength
+   end % while over full file
+   if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+      textMessage = 'Pass 1 of 3: Parsing blocks';
+      waitbar(double(iRelativePosition)/double(sizeAllScansInBytes), Control.GUI.hWaitBar, textMessage);
+   end
+   if ((iRelativePosition < sizeAllScansInBytes) && bHasACQEND)         
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'WARNING','ACQ_END before end of file.');
+         keyboard
+      end
+   end
+   if ~bHasACQEND
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'WARNING','No ACQ_END encountered.  Data possibly incomplete or corrupted.');
+      end
+   end
+   nBlockSYNCDATA = sum([MdhBlock.isSyncData]);
+   nBlockACQEND = sum([MdhBlock.isAcqEnd]);
+   indexScan = find(([MdhBlock.isAcqEnd] == 0) & ([MdhBlock.isSyncData] == 0) & ([MdhBlock.keepScan] > 0));
+   nBlockScanAll = length(indexScan);
+   if nBlockScanAll < 1
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('No readouts detected for meas %d.', iMeas),'Warning');
+      end
+      %fclose(fid);
+      sizeAllScansInBytes = [];
+      sizeChanInBytes = [];
+      MdhBlock = [];
+      nBlockSYNCDATA = [];
+      nBlockACQEND = [];
+      nBlockScan = [];
+      blockNScan = [];
+      nScanInMeas = [];
+      dmaLengthScan = [];
+      nSamplesInScan = [];
+      return
+   end
+
+   nSamplesInScanUnique = unique([MdhBlock(indexScan).nSamplesInScan]);
+   nScanInMeas = uint64(sum([MdhBlock(indexScan).nScan]));
+   if (length(nSamplesInScanUnique) == 1)
+      nBlockScan = nBlockScanAll;
+      blockNScan = [MdhBlock(indexScan).nScan];
+      if (length(unique([MdhBlock(indexScan).dmaLength])) ~= 1) && ~MrParcRaidFileCell{iMeas}.Control.User.noKSpace
+         if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+            if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+               display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('Multiple different dmaLength in meas %d',iMeas),'Warning');
+            else
+               display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'ERROR',sprintf('Multiple different dmaLength in meas %d',iMeas),'Error');
+               keyboard
+               fclose(fid);
+            end
+         end
+         sizeAllScansInBytes = [];
+         sizeChanInBytes = [];
+         MdhBlock = [];
+         nBlockSYNCDATA = [];
+         nBlockACQEND = [];
+         nBlockScan = [];
+         blockNScan = [];
+         nScanInMeas = [];
+         dmaLengthScan = [];
+         nSamplesInScan = [];
+         return
+      end
+      dmaLengthScan = MdhBlock(indexScan(1)).dmaLength;
+      nSamplesInScan = nSamplesInScanUnique(1);
+      sizeChanInBytes = MdhBlock(indexScan(1)).sizeFirstChanInBytes;
+   else
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+            display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('Multiple different samples per scan in meas %d',iMeas),'Warning');
+         else
+            if ~MrParcRaidFileCell{iMeas}.Control.User.noKSpace
+               display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'ERROR',sprintf('Multiple different samples per scan in meas %d',iMeas),'Error');
+               keyboard
+            end
+         end
+      end
+   end
+end
+
+% =============================================================================
+function [evalMaskArray, sizeAllScansInBytes, sizeChanInBytes, MdhBlock, nBlockSYNCDATA, ...
+          nBlockACQEND, nBlockScan, blockNScan, nScanInMeas, dmaLengthScan, ...
+          nSamplesInScan] = ...
+             chunk_into_equal_line_length_blocks(fid,MrParcRaidFileCell, iMeas, Dim, Control)
+% -----------------------------------------------------------------------------
+% -----------------------------------------------------------------------------
+   global MDH_SCANSIZE MAX_BYTES_PER_FREAD
+   global MDH_HEX2DEC_FFFFFF
+
+   if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+      mdhParamToExtract = {'dmaLength','nSamplesInScan','nChannelUsed','evalMask'};
+   else
+      mdhParamToExtract = {'dmaLength','nSamplesInScan','nChannelUsed'};
+   end
+   evalMaskArray = {};
+   sizeAllScansInBytes = MrParcRaidFileCell{iMeas}.totalSize - Dim.ullMeasHeaderSize;
+   fseek(fid,MrParcRaidFileCell{iMeas}.offsetInFile + Dim.ullMeasHeaderSize,'bof');
+   % Read the first line to get the DMA length and line type
+   mdhScan = fread(fid,MDH_SCANSIZE+4,'uchar=>uchar');
+   MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+   if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+      evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+      if isempty(find(strcmp(evalMaskArray,evalStr)))
+         evalMaskArray{length(evalMaskArray)+1} = evalStr;
+      end
+   end
+   MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+   bHasACQEND = MdhBitFlags.isAcqEnd;
+   bKeepScan = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+   dmaLength = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes used for dmaLength
+   sizeFirstChanInBytes = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+   iRelativePosition = uint64(1);
+   iBlock = 1;
+   offsetInFile = MrParcRaidFileCell{iMeas}.offsetInFile + Dim.ullMeasHeaderSize;
+   % NOTE: We make a very simple assumption that the same number of
+   %    samples per scan will hold for scans of the same dmaLength
+   % Similarly for the number of channels (which mean nothing in SYNCDATA scans)
+   MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+   while ((iRelativePosition < sizeAllScansInBytes) && ~bHasACQEND)
+      if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+         textMessage = 'Pass 1 of 3: Parsing blocks';
+         waitbar(double(iRelativePosition)/double(sizeAllScansInBytes), Control.GUI.hWaitBar, textMessage);
+      end
+      fseek(fid,MdhBlock(iBlock).offsetInFile + MdhBlock(iBlock).nScan * dmaLength,'bof');
+      bytesRemaining = sizeAllScansInBytes-iRelativePosition+uint64(1);
+      if dmaLength < 2048
+         nScanToRead=uint64(177);  % We don't usually get a lot short lines
+      else
+         nScanToRead = max(idivide(MAX_BYTES_PER_FREAD, dmaLength,'fix'),uint64(1));
+      end   
+      %if iBlock > 20
+      %   indexKeep = find([MdhBlock.keepScan]);
+      %   if length(indexKeep) > 0
+      %      nScanToRead = min(nScanToRead, median([MdhBlock(indexKeep).nScan]));
+      %   end
+      %end
+      bytesToRead = nScanToRead*dmaLength;
+      if (bytesToRead > bytesRemaining)
+         nScanToRead = idivide(bytesRemaining,dmaLength,'fix');
+         if nScanToRead < 1
+            [mdhScan, readCount] = fread(fid,MDH_SCANSIZE+4,'uchar=>uchar');
+            MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+            if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+               evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+               if isempty(find(strcmp(evalMaskArray,evalStr)))
+                  evalMaskArray{length(evalMaskArray)+1} = evalStr;
+               end
+            end
+            MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+            bKeepScanNext = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+            dmaLengthNext = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes used by dmaLength
+            if readCount > MDH_SCANSIZE
+               sizeFirstChanInBytesNext = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+            else
+               sizeFirstChanInBytesNext = uint64(0);
+            end
+            nScanToRead = uint64(1);
+            if (dmaLengthNext == dmaLength) && (bKeepScan == bKeepScanNext)
+               error_message
+            else
+               iBlock = iBlock + 1;
+               offsetInFile = MdhBlock(iBlock-1).offsetInFile + MdhBlock(iBlock-1).nScan * dmaLength;
+               dmaLength = dmaLengthNext;
+               bKeepScan = bKeepScanNext;
+               sizeFirstChanInBytes = sizeFirstChanInBytesNext;
+               MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+               fseek(fid,MdhBlock(iBlock).offsetInFile + MdhBlock(iBlock).nScan * dmaLength,'bof');
+            end
+         end
+      end
+      bytesToRead = dmaLength*nScanToRead;
+      [blockOfScans, readCount] = fread(fid,bytesToRead,'uchar=>uchar');
+      if MdhBlock(iBlock).isAcqEnd && (readCount < bytesToRead)
+         dmaLength = uint64(readCount / nScanToRead);
+      end
+      iStart = int64(1);
+      while (uint64(iStart) + MDH_SCANSIZE - 1) <= readCount
+         mdhScan = blockOfScans(uint64(iStart):min(uint64(iStart)+MDH_SCANSIZE+4-1,readCount));
+         MdhParam = extract_mdh_parameters(mdhScan, 'scan', mdhParamToExtract);
+         if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+            evalStr = sprintf('%d, %d, %d, %u', MdhParam.dmaLength, MdhParam.nSamplesInScan, MdhParam.nChannelUsed, MdhParam.evalMask);
+            if isempty(find(strcmp(evalMaskArray,evalStr)))
+               evalMaskArray{length(evalMaskArray)+1} = evalStr;
+            end
+         end
+         MdhBitFlags = extract_mdh_bitflags(mdhScan, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM'});
+         bKeepScanNext = MdhBitFlags.bKeepEIM(1) && ~MdhBitFlags.bDropEIM(1);
+         dmaLengthNext = uint64(bitand(MdhParam.dmaLength,MDH_HEX2DEC_FFFFFF)); % Only first 3 bytes for dmaLength
+         if length(mdhScan) > MDH_SCANSIZE
+            sizeFirstChanInBytesNext = uint64(bitshift(extract_single_mdh_parameter(mdhScan(MDH_SCANSIZE+1:MDH_SCANSIZE+4),'chan','sizeChanInBytes'),-8));
+         else
+            sizeFirstChanInBytesNext = uint64(0);
+         end
+         bHasACQEND = bHasACQEND || MdhBlock(iBlock).isAcqEnd;
+         if (dmaLengthNext == dmaLength) && (bKeepScanNext == bKeepScan)
+            MdhBlock(iBlock).nScan = MdhBlock(iBlock).nScan + 1;
+            iRelativePosition = iRelativePosition + dmaLength;
+         else
+            iBlock = iBlock + 1;
+            offsetInFile =MdhBlock(iBlock-1).offsetInFile + MdhBlock(iBlock-1).nScan * dmaLength;
+            flagDMALengthChange = dmaLength ~= dmaLengthNext;
+            dmaLength = dmaLengthNext;
+            bKeepScan = bKeepScanNext;
+            sizeFirstChanInBytes = sizeFirstChanInBytesNext;
+            MdhBlock(iBlock) = init_mdh_block(offsetInFile, dmaLength, sizeFirstChanInBytes, MdhBitFlags, MdhParam);
+            if flagDMALengthChange % No need to reread a chunk if dma length has not changed
+               break;
+            end
+            iStart = iStart - int64(dmaLength); % backup and re-read this data into a the new block
+         end
+         if bHasACQEND
+            break;
+         end
+         iStart = iStart + int64(dmaLength);
+      end % for over block of scans with same dmalength
+   end % while over full file
+   if ~(MrParcRaidFileCell{iMeas}.Control.User.noGui || MrParcRaidFileCell{iMeas}.Control.User.silent)
+      textMessage = 'Pass 1 of 3: Parsing blocks';
+      waitbar(double(iRelativePosition)/double(sizeAllScansInBytes), Control.GUI.hWaitBar, textMessage);
+   end
+   if ((iRelativePosition < sizeAllScansInBytes) && bHasACQEND)         
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'WARNING','ACQ_END before end of file.');
+      end
+   end
+   if ~bHasACQEND
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'WARNING','No ACQ_END encountered.  Data possibly incomplete or corrupted.');
+      end
+   end
+   nBlockSYNCDATA = sum([MdhBlock.isSyncData]);
+   nBlockACQEND = sum([MdhBlock.isAcqEnd]);
+   indexScan = find(([MdhBlock.isAcqEnd] == 0) & ([MdhBlock.isSyncData] == 0) & ([MdhBlock.keepScan] > 0));
+   nBlockScanAll = length(indexScan);
+   if nBlockScanAll < 1
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('No readouts detected for meas %d.', iMeas),'Warning');
+      end
+      %fclose(fid);
+      sizeAllScansInBytes = [];
+      sizeChanInBytes = [];
+      MdhBlock = [];
+      nBlockSYNCDATA = [];
+      nBlockACQEND = [];
+      nBlockScan = [];
+      blockNScan = [];
+      nScanInMeas = [];
+      dmaLengthScan = [];
+      nSamplesInScan = [];
+      return
+   end
+
+   nSamplesInScanUnique = unique([MdhBlock(indexScan).nSamplesInScan]);
+   nScanInMeas = uint64(sum([MdhBlock(indexScan).nScan]));
+   if (length(nSamplesInScanUnique) == 1)
+      nBlockScan = nBlockScanAll;
+      blockNScan = [MdhBlock(indexScan).nScan];
+      if (length(unique([MdhBlock(indexScan).dmaLength])) ~= 1)
+         if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+            if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+               display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('Multiple different dmaLength in meas %d',iMeas),'Warning');
+            else
+               display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'ERROR',sprintf('Multiple different dmaLength in meas %d',iMeas),'Error');
+               keyboard
+               fclose(fid);
+            end
+         end
+         sizeAllScansInBytes = [];
+         sizeChanInBytes = [];
+         MdhBlock = [];
+         nBlockSYNCDATA = [];
+         nBlockACQEND = [];
+         nBlockScan = [];
+         blockNScan = [];
+         nScanInMeas = [];
+         dmaLengthScan = [];
+         nSamplesInScan = [];
+         return
+      end
+      dmaLengthScan = MdhBlock(indexScan(1)).dmaLength;
+      nSamplesInScan = nSamplesInScanUnique(1);
+      sizeChanInBytes = MdhBlock(indexScan(1)).sizeFirstChanInBytes;
+   else
+      if ~MrParcRaidFileCell{iMeas}.Control.User.silent
+         if MrParcRaidFileCell{iMeas}.Control.User.scanEvalInfoMaskOnly
+            display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'Warning',sprintf('Multiple different samples per scan in meas %d',iMeas),'Warning');
+         else
+            display_message(MrParcRaidFileCell{iMeas}.Control.User.noGui,'ERROR',sprintf('Multiple different samples per scan in meas %d',iMeas),'Error');
+            keyboard
+         end
+      end
+   end
+end
+
+% =============================================================================
+function PMUOut = extract_pmu(fid,MdhBlock,Control)
+% -----------------------------------------------------------------------------
+% Read the PMU data from SYNCDATA lines
+% -----------------------------------------------------------------------------
+
+   global MDH_SCANSIZE MDH_PMUSIZE
+
+   PMU.TimeStamp.nColumn = 0;
+   PMU.TimeStamp.raw = reshape([],2,0);
+   PMU.TimeStamp.data = reshape([],2,0);
+   Waveform.typeName = '';
+   Waveform.nColumn = 0;
+   Waveform.nRow = 0;
+   Waveform.period = 0;
+   Waveform.data = [];
+   Waveform.trigger = [];
+   pmuTypes = {'ECG1', 'ECG2', 'ECG3', 'ECG4', 'PULS', 'RESP', 'EXT1', 'EXT2'};
+   PMU.Waveforms = repmat(Waveform,1,length(pmuTypes));
+   for iType=1:length(pmuTypes)
+      PMU.Waveforms(iType).typeName = pmuTypes(iType);
+   end
+   for iBlock = 1:length(MdhBlock)
+
+      % Skip non-SYNCDATA
+      if ~MdhBlock(iBlock).isSyncData 
+         continue
+      end
+
+      fseek(fid,MdhBlock(iBlock).offsetInFile,'bof');
+      nScanToRead = MdhBlock(iBlock).nScan;
+      blockOfScans = fread(fid,[MdhBlock(iBlock).dmaLength nScanToRead],'uchar=>uchar');
+  
+      offset = MDH_SCANSIZE + MDH_PMUSIZE;
+
+      % PMU Header
+      MdhParam = extract_mdh_parameters(blockOfScans(offset+1:end,:), 'pmu', {'timeStamp', 'duration', 'data'});
+      pmuTimeStamp = reshape(MdhParam.timeStamp,2,nScanToRead);
+      pmuDuration = MdhParam.duration;
+
+      PMU.TimeStamp.raw(:,PMU.TimeStamp.nColumn+1:PMU.TimeStamp.nColumn + nScanToRead) = pmuTimeStamp;
+      PMU.TimeStamp.data(:,PMU.TimeStamp.nColumn+1:PMU.TimeStamp.nColumn + nScanToRead) = double(pmuTimeStamp) * 2.5d-3;
+      PMU.TimeStamp.nColumn = PMU.TimeStamp.nColumn + nScanToRead;
+
+      %pmuDataOld = blockOfScans(offset+17:end,:);
+      nPmuPoints = idivide(MdhBlock(iBlock).dmaLength - offset - uint64(16),uint64(4),'fix');
+      pmuData = reshape(MdhParam.data,nPmuPoints,nScanToRead);
+
+      iPmuPoint = 1;
+      while iPmuPoint <= nPmuPoints
+
+         pmuType = bitshift(bitand(1.0*pmuData(iPmuPoint,:),hex2dec('010F0000'),'uint32'),-16) - 256;
+         if length(unique(pmuType)) ~= 1
+            if ~Control.User.silent
+               display_message(Control.User.noGui,'ERROR','Unexpected PMU type data','PMU Problem');
+            end
+            fclose(fid);
+            PMUOut = [];
+            return;
+         else
+            pmuType = unique(pmuType);
+         end
+         % Check for end of data magic
+         if (pmuType < 1) || (pmuType > 8)
+            break 
+         end
+         pmuPeriod = pmuData(iPmuPoint+1,:);
+         nPeriod = idivide(pmuDuration(:),pmuPeriod(:),'fix');
+         if (length(unique(nPeriod)) ~= 1) || (length(unique(pmuPeriod(:))) ~= 1)
+            if ~Control.User.silent
+               display_message(Control.User.noGui,'ERROR','Unexpected PMU period or point data','PMU Problem');
+            end
+            fclose(fid);
+            PMUOut = [];
+            return;
+         else
+            nPeriod = unique(nPeriod);
+            pmuPeriod = unique(pmuPeriod);
+         end
+         
+         pmuPoint = uint32(iPmuPoint);
+         pmuThisData = pmuData(pmuPoint+2:pmuPoint+2+nPeriod-1,:);
+         % Waveforms are the lower 12 bits
+         pmuWaveform = bitand(1.0*pmuThisData,hex2dec('00000fff'),'uint32');
+         % Triggers in higher bits
+         pmuTriggers = bitand(1.0*pmuThisData,hex2dec('fffff000'),'uint32');
+
+         if PMU.Waveforms(pmuType).period == 0
+            PMU.Waveforms(pmuType).period = (double(pmuPeriod) * 100d-6);
+         else
+            if PMU.Waveforms(pmuType).period ~= (double(pmuPeriod)*100d-6)
+               if ~Control.User.silent
+                  display_message(Control.User.noGui,'ERROR','Unexpected PMU period','PMU Problem');
+               end
+               fclose(fid);
+               PMUOut = [];
+               return;
+
+            end
+         end
+         PMU.Waveforms(pmuType).data(1:nPeriod,PMU.Waveforms(pmuType).nColumn+1:PMU.Waveforms(pmuType).nColumn + nScanToRead) = pmuWaveform;
+         PMU.Waveforms(pmuType).trigger(1:nPeriod,PMU.Waveforms(pmuType).nColumn+1:PMU.Waveforms(pmuType).nColumn + nScanToRead) = pmuTriggers;
+         PMU.Waveforms(pmuType).nRow(PMU.Waveforms(pmuType).nColumn+1:PMU.Waveforms(pmuType).nColumn + nScanToRead) = nPeriod;
+         PMU.Waveforms(pmuType).nColumn = PMU.Waveforms(pmuType).nColumn + nScanToRead;
+
+         % Need to jump our pointer forward
+         iPmuPoint = iPmuPoint + 2 + double(nPeriod);
+
+      end
+
+   end % for over blocks
+
+   % Consolidate values
+   WaveformOut.typeName = '';
+   WaveformOut.nPoint = 0;
+   WaveformOut.time = [];
+   WaveformOut.data = [];
+   WaveformOut.trigger = [];
+   pmuTypes = {'ECG1', 'ECG2', 'ECG3', 'ECG4', 'PULS', 'RESP', 'EXT1', 'EXT2'};
+   PMUOut.TimeStamp = PMU.TimeStamp;
+   PMUOut.Waveforms = repmat(WaveformOut,1,length(pmuTypes));
+   for iType=1:length(pmuTypes)
+      PMUOut.Waveforms(iType).typeName = pmuTypes(iType);
+      nRowTotal = sum(PMU.Waveforms(iType).nRow(:));
+      PMUOut.Waveforms(iType).data = uint32(0) * zeros(1,nRowTotal,'uint32');
+      PMUOut.Waveforms(iType).trigger = uint32(0)*zeros(1,nRowTotal,'uint32');
+      PMUOut.Waveforms(iType).time = 0 * zeros(1,nRowTotal);
+      iStart = 1;
+      PMUOut.Waveforms(iType).nPoint = nRowTotal;
+      for iCol=1:PMU.Waveforms(iType).nColumn
+
+         nRow = PMU.Waveforms(iType).nRow(iCol);
+         timeRelative = (0:(nRow-1)) * PMU.Waveforms(iType).period;
+         timeStart = PMU.TimeStamp.data(2,iCol);
+         timeValues = timeStart + timeRelative;
+         waveValues = PMU.Waveforms(iType).data(1:nRow,iCol);
+         triggers = PMU.Waveforms(iType).trigger(1:nRow,iCol);
+
+         PMUOut.Waveforms(iType).time(iStart:iStart+nRow-1) = timeValues(:);
+         PMUOut.Waveforms(iType).data(iStart:iStart+nRow-1) = waveValues(:);
+         PMUOut.Waveforms(iType).trigger(iStart:iStart+nRow-1) = triggers(:);
+
+         iStart = iStart + nRow;
+
+      end
+   end
+
+   clear PMU;
+
+end
+
+% =============================================================================
+function [dimNames, nScan, n, kSpaceCentreLineNo, kSpaceCentrePartitionNo, ...
+          order, dimOut, dimOutProd, channelIDUniq] = ...
+         scan_mdh_for_dim_and_order(fid,Dim,Control,sizeChanInBytes,MdhBlock,nScanInMeas,nSamplesInScan)
+% -----------------------------------------------------------------------------
+% -----------------------------------------------------------------------------
+
+   global MDH_SCANSIZE MAX_BYTES_PER_FREAD
+   global index_keys
+
+   iScanRead = uint64(0);
+   timeRemain = uint64(10000000);
+   dimNames  = {'CHA', 'LIN', 'SLC', 'PAR', 'ACQ', 'ECO', 'PHS', 'REP', 'SET', 'SEG', 'IDA', 'IDB', 'IDC', 'IDD', 'IDE'};
+   indexPrev.dumby = 0; % Placeholder
+   dimValue = uint16(0)*uint16(zeros(1,length(dimNames)));
+   dimRank = uint64(zeros(1,length(dimNames)));
+   nScan = 0;
+   if ~(Control.User.noGui || Control.User.silent)
+      time0 = tic;
+   end
+
+   kSpaceCentreLineNo = [];
+   kSpaceCentrePartitionNo = [];
+
+   % Instead of looping through blocks, we partition them into meta-blocks
+   %    of the same number of samples per scan
+   iBlock = 1;
+   iBlockMeta = 1;
+   MdhBlockMeta = append_to_mdhblockmeta(iBlock, iBlockMeta, MdhBlock);
+   for iBlock=2:length(MdhBlock)
+
+      indexMatch = find((cell2mat({MdhBlockMeta.isSyncData}) == MdhBlock(iBlock).isSyncData) & ...
+                        (cell2mat({MdhBlockMeta.isAcqEnd}) == MdhBlock(iBlock).isAcqEnd) & ...
+                        (cell2mat({MdhBlockMeta.keepScan}) == MdhBlock(iBlock).keepScan) & ...
+                        (cell2mat({MdhBlockMeta.dmaLength}) == MdhBlock(iBlock).dmaLength) & ...
+                        (cell2mat({MdhBlockMeta.nSamplesInScan}) == MdhBlock(iBlock).nSamplesInScan) & ...
+                        (cell2mat({MdhBlockMeta.nChannelUsed}) == MdhBlock(iBlock).nChannelUsed));
+      if numel(indexMatch) > 0
+         MdhBlockMeta(indexMatch(1)).nBlock = MdhBlockMeta(indexMatch(1)).nBlock + 1;
+         MdhBlockMeta(indexMatch(1)).iBlock(MdhBlockMeta(indexMatch(1)).nBlock) = iBlock;
+         MdhBlockMeta(indexMatch(1)).nScan = MdhBlockMeta(indexMatch(1)).nScan + MdhBlock(iBlock).nScan;
+      else 
+         iBlockMeta = iBlockMeta + 1;
+         MdhBlockMeta = append_to_mdhblockmeta(iBlock, iBlockMeta, MdhBlock, MdhBlockMeta);
+      end
+   end % for over MdhBlock
+
+   for iBlockMeta = 1:length(MdhBlockMeta)
+
+      % Skip SYNCDATA and blocked lines
+      if MdhBlockMeta(iBlockMeta).isSyncData || MdhBlockMeta(iBlockMeta).isAcqEnd || ~MdhBlockMeta(iBlockMeta).keepScan 
+         continue
+      end
+
+      for iBlockInner = 1:length(MdhBlockMeta(iBlockMeta).iBlock)
+
+         iBlock = MdhBlockMeta(iBlockMeta).iBlock(iBlockInner);
+
+         maxScanPerRead = max(idivide(MAX_BYTES_PER_FREAD,MdhBlock(iBlock).dmaLength,'fix'),uint64(1));
+         nScanToRead = min(maxScanPerRead,MdhBlock(iBlock).nScan);
+
+         fseek(fid,MdhBlock(iBlock).offsetInFile,'bof');
+         nScanRemainInBlock = MdhBlock(iBlock).nScan;
+
+         iScanReadBlock = uint64(0);
+         while nScanRemainInBlock > 0
+
+            if ~(Control.User.noGui || Control.User.silent)
+               dTimeElapsed = toc(time0);
+               rate = dTimeElapsed / (double(iScanRead) + 1);
+               if dTimeElapsed > 20
+                  timeRemain = min(double(nScanInMeas - iScanRead) * rate,timeRemain);
+               else
+                  timeRemain = double(nScanInMeas - iScanRead) * rate;
+               end
+               textMessage = sprintf('Pass 2 of 3\nScanning dimensions from MDH\nTime remaining (s): %d', uint32(timeRemain));
+               waitbar(double(iScanRead)/double(nScanInMeas), Control.GUI.hWaitBar, textMessage);
+            end
+
+            blockOfScans = fread(fid,[MdhBlock(iBlock).dmaLength nScanToRead],'uchar=>uchar');
+            MdhParam = extract_mdh_parameters(blockOfScans, 'scan', index_keys);
+            if Control.User.collapseSeg
+               MdhParam.indexSEG = MdhParam.indexSEG * uint16(0);
+            end
+            MdhBitFlags = extract_mdh_bitflags(blockOfScans, {'isAcqEnd', 'isSyncData', 'bKeepEIM', 'bDropEIM', 'isNoiseAdj', 'isPhaseCor', 'isRawDataCorrection', 'isReflect'});
+
+            bHasACQEND = max(MdhBitFlags.isAcqEnd);
+            if bHasACQEND
+               break
+            end
+            channelID = uint16(0) * zeros(MdhBlock(iBlock).nChannelUsed,nScanToRead,'uint16');
+            for iCha = 1:MdhBlock(iBlock).nChannelUsed
+               offset  = uint64(MDH_SCANSIZE) + uint64(iCha-1) * sizeChanInBytes;
+               channelID(iCha,:) = reshape(extract_single_mdh_parameter(blockOfScans(offset+1:offset+sizeChanInBytes,:),'chan','channelID'),[1,nScanToRead]);
+            end
+            channelIDUniq = unique(channelID(:));
+            if prod(channelIDUniq == channelID(:,1)) == 0
+               disp('Channels are not in monotonic order in data')
+               keyboard
+            end
+            channelIDUniqNum = length(channelIDUniq);
+            if (channelIDUniqNum ~= MdhBlock(iBlock).nChannelUsed) || (sum(channelIDUniq == channelID(:,1)) ~= MdhBlock(iBlock).nChannelUsed)
+               if ~Control.User.silent
+                  display_message(Control.User.noGui,'ERROR',['Mismatch between nChannel and coils found: ' int2str(channelIDUniqNum) ' ' int2str(MdhBlock(iBlock).nChannelUsed)],'Dimension Conflict');
+               end
+               fclose(fid);
+               dimNames = [];
+               nScan = [];
+               n = [];
+               kSpaceCentreLineNo = [];
+               kSpaceCentrePartitionNo = [];
+               order = [];
+               dimOut = [];
+               dimOutProd = [];
+               channelIDUniq = [];
+               return;
+            end
+            maskKeep = MdhBitFlags.bKeepEIM & ~MdhBitFlags.bDropEIM;
+            index = find(maskKeep);
+            if nScan == 0
+               kSpaceCentreLineNo = extract_single_mdh_parameter(blockOfScans(:,index(1)),'scan','kSpaceCentreLineNo');
+               kSpaceCentrePartitionNo = extract_single_mdh_parameter(blockOfScans(:,index(1)),'scan','kSpaceCentrePartitionNo');
+            end
+            nScan = nScan + numel(index);
+            dimValue = max_from_mdh_param(dimValue, MdhBlock(iBlock).nChannelUsed, dimNames, MdhParam, index(:));
+            if numel(index) > 1
+               dimRank = rank_from_mdh_param(dimRank, dimNames, MdhParam, MdhBlock(iBlock).nChannelUsed, index(:));
+            end
+            if numel(index) == 1
+               dimRank(1) = dimRank(1) + uint64(MdhBlock(iBlock).nChannelUsed);
+            end
+            if (iBlockInner > 1) && ~isempty(indexPrev) 
+               dimRank = rank_from_index_prev(dimRank, ...
+                                              dimNames, ...
+                                              MdhParam, ...
+                                              MdhBlock(iBlock).nChannelUsed, ...
+                                              index(1), ...
+                                              indexPrev);
+            end
+            if MdhBlock(iBlock).nChannelUsed < 2
+               dimRank(1)=uint64(0);
+            end
+            if numel(index) > 0
+               indexPrev = set_index_prev(dimNames, MdhParam, index(end));
+            else
+               if ~isempty(indexPrev)
+                  indexPrev = [];
+               end
+            end
+
+            iScanRead = iScanRead + nScanToRead;
+            iScanReadBlock = iScanReadBlock + nScanToRead;
+            nScanRemainInBlock = MdhBlock(iBlock).nScan - iScanReadBlock;
+            nScanToRead = min(nScanToRead,nScanRemainInBlock);
+
+         end % while over subsets of blocked lines
+
+      end % for over blocks of non-syncdata
+
+   end % over blocks of the same size
+
+   if ~(Control.User.noGui || Control.User.silent)
+      waitbar(0.5, Control.GUI.hWaitBar, 'MDH Scan complete');
+   end
+   clear blockOfScans;
+   clear channelID MdhParam MdhBitFlags;
+   clear index;
+   clear iScanRead iScanReadInBlock nScanToRead;
+
+   dimValue = dimValue .* uint16(dimRank > 0) + 1;
+   for dimCell = {{'CHA' 1  false ''    ''     false ''      ''                   ''      ''    } ...
+                  {'LIN' 2  false ''    ''     true  'Recon' 'nFourierLines'      'Recon' 'nLin'} ...
+                  {'SLC' 3  false ''    ''     true  ''      ''                   'Recon' 'nSlc'} ...
+                  {'PAR' 4  false ''    ''     true  'Recon' 'nFourierPartitions' 'Recon' 'nPar'} ...
+                  {'ACQ' 5   true 'Raw' 'nAcq' false ''      ''                   ''      ''    } ...
+                  {'ECO' 6   true 'Raw' 'nEco' false ''      ''                   ''      ''    } ...
+                  {'PHS' 7   true 'Raw' 'nPhs' false ''      ''                   ''      ''    } ...
+                  {'REP' 8   true 'Raw' 'nRep' false ''      ''                   ''      ''    } ...
+                  {'SET' 9   true 'Raw' 'nSet' false ''      ''                   ''      ''    } ...
+                  {'SEG' 10  false ''    ''    false ''      ''                   ''      ''    } ...
+                  {'IDA' 11  false ''    ''    false ''      ''                   ''      ''    } ...
+                  {'IDB' 12  false ''    ''    false ''      ''                   ''      ''    } ...
+                  {'IDC' 13  false ''    ''    false ''      ''                   ''      ''    } ...
+                  {'IDD' 14  false ''    ''    false ''      ''                   ''      ''    } ...
+                  {'IDE' 15  false ''    ''    false ''      ''                   ''      ''    }}
+      % Initialize with dimValue
+      n.(dimCell{1}{1}) = dimValue(dimCell{1}{2});
+      % Update with max from Dim structure
+      if dimCell{1}{3} && (n.(dimCell{1}{1}) > 1)
+         n.(dimCell{1}{1}) = max(n.(dimCell{1}{1}), Dim.(dimCell{1}{4}).(dimCell{1}{5}));
+      end
+      % Special handling in FillToFullFourier cases
+      if dimCell{1}{6}
+         if ~Control.User.noFillToFullFourier
+            if ~isempty(dimCell{1}{7}) 
+               n.(dimCell{1}{1}) = max(n.(dimCell{1}{1}), Dim.(dimCell{1}{7}).(dimCell{1}{8}));
+            end
+            if ~isempty(dimCell{1}{9}) > 0
+               n.(dimCell{1}{1}) = max(n.(dimCell{1}{1}), Dim.(dimCell{1}{9}).(dimCell{1}{10}));
+            end
+         end
+      end
+   end
+   dimOut = uint64([n.CHA n.LIN n.SLC n.PAR n.ACQ n.ECO n.PHS n.REP n.SET n.SEG n.IDA n.IDB n.IDC n.IDD n.IDE]);
+   [~, order] = sort(dimRank, 2, 'descend');
+   %keyboard
+   dimOut = dimOut(order);
+   dimOutProd = [uint64(1) compute_cumulative_product(dimOut(1:end-1))];
+
+   if Control.User.noFillToFullFourier == true 
+      n.COL = nSamplesInScan;
+   else
+      n.COL = max(nSamplesInScan, uint64(Dim.Recon.readoutFTLength));
+   end
+
+   clear dimValue dimRank;
+
+end
+
+% =============================================================================
+function [status, rot_matrix] = quaternion_to_rotation_matrix(quaternion)
+% -----------------------------------------------------------------------------
+% PURPOSE:   Based on MdhProxy class method, converts quaternions into 
+%               rotation matrix relating PRS to SagCorTra
+% NOTES:     From MdhProxy.h
+%        cout << "mdh::getRotMatrix: Gp = " << adRotMatrix[0][0] << " * Gsag + " <<
+%                                              adRotMatrix[0][1] << " * Gcor + " <<
+%                                              adRotMatrix[0][2] << " * Gtra\n";
+%        cout << "mdh::getRotMatrix: Gr = " << adRotMatrix[1][0] << " * Gsag + " <<
+%                                              adRotMatrix[1][1] << " * Gcor + " <<
+%                                              adRotMatrix[1][2] << " * Gtra\n";
+%        cout << "mdh::getRotMatrix: Gs = " << adRotMatrix[2][0] << " * Gsag + " <<
+%                                              adRotMatrix[2][1] << " * Gcor + " <<
+%                                              adRotMatrix[2][2] << " * Gtra\n";
+%        cout << "mdh::getRotMatrix: ...finished" << endl; 
+% -----------------------------------------------------------------------------
+
+   MDH_QW = 1;
+   MDH_QX = 2;
+   MDH_QY = 3;
+   MDH_QZ = 4;
+
+   if sum(quaternion(:)) == 0
+      status = 1;
+      rot_matrix = [];
+      return
+   end
+
+   ds = 2.0 / (quaternion(MDH_QW) * quaternion(MDH_QW) + ...
+               quaternion(MDH_QX) * quaternion(MDH_QX) + ...
+               quaternion(MDH_QY) * quaternion(MDH_QY) + ...
+               quaternion(MDH_QZ) * quaternion(MDH_QZ));
+
+   dxs = quaternion(MDH_QX) *  ds;
+   dys = quaternion(MDH_QY) *  ds;
+   dzs = quaternion(MDH_QZ) *  ds;
+
+   dwx = quaternion(MDH_QW) * dxs;
+   dwy = quaternion(MDH_QW) * dys;
+   dwz = quaternion(MDH_QW) * dzs;
+
+   dxx = quaternion(MDH_QX) * dxs;
+   dxy = quaternion(MDH_QX) * dys;
+   dxz = quaternion(MDH_QX) * dzs;
+
+   dyy = quaternion(MDH_QY) * dys;
+   dyz = quaternion(MDH_QY) * dzs;
+   dzz = quaternion(MDH_QZ) * dzs;
+
+   rot_matrix = zeros(3);
+   rot_matrix(1,1) = 1.0 - (dyy + dzz);
+   rot_matrix(1,2) =        dxy + dwz;
+   rot_matrix(1,3) =        dxz - dwy;
+   rot_matrix(2,1) =        dxy - dwz;
+   rot_matrix(2,2) = 1.0 - (dxx + dzz);
+   rot_matrix(2,3) =        dyz + dwx;
+   rot_matrix(3,1) =        dxz + dwy;
+   rot_matrix(3,2) =        dyz - dwx;
+   rot_matrix(3,3) = 1.0 - (dxx + dyy);
+
+   status = 0;
+
+   return
+
+end
+
+
+% =============================================================================
+% -----------------------------------------------------------------------------
+% -----------------------------------------------------------------------------
+

--- a/matlab/read_kspace_dependencies/jGetFileInfo.m
+++ b/matlab/read_kspace_dependencies/jGetFileInfo.m
@@ -1,0 +1,358 @@
+% --------------------------------------------------------------------------------
+% FileInfo=jGetFileInfo(FileName)
+% Jason Mendes - UCAIR - University of Utah - 2015
+% --------------------------------------------------------------------------------
+% This function opens the .dat file and retrieves information about the sequence
+% data stored.
+% --------------------------------------------------------------------------------
+function FileInfo=jGetFileInfo(FileName,PrintHeader)
+
+if nargin < 2
+    PrintHeader = 1;
+end
+
+% Prompt for filename if one is not specified
+if ((exist('FileName')~=1)||isempty(FileName))
+	[file_name,path_name]=uigetfile('*.dat','Select Raw Data File');
+	FileName=sprintf('%s%s',path_name,file_name);
+end
+
+% Open the .dat file
+FileInfo=[];
+FileInfo.FileId=fopen(FileName,'r');
+if (FileInfo.FileId<0)
+   error('jGetFileInfo(): Could not open file specified');
+end
+fseek(FileInfo.FileId,0,'eof');
+FileSize=ftell(FileInfo.FileId);
+FileInfo.FileName=FileName;
+
+% Find BaselineString
+fseek(FileInfo.FileId,0,'bof');
+while (ftell(FileInfo.FileId)<FileSize)
+   NextLine=fgets(FileInfo.FileId);
+   if (~isempty(findstr(NextLine,'<ParamString."tMeasuredBaselineString">')))
+      Data=jReadSimpleString(FileInfo,NextLine);
+      if (~isempty(findstr(lower(Data.String),'n4_v')))
+         FileInfo.Version=Data.String;
+         break;
+      end
+   elseif (~isempty(findstr(NextLine,'<ParamString."tBaselineString">')))
+      Data=jReadSimpleString(FileInfo,NextLine);
+      if (~isempty(findstr(lower(Data.String),'n4_v')))
+         FileInfo.Version=Data.String;
+         break;
+      end
+   end
+end
+
+% If no version is found try and guess one
+if (~isfield(FileInfo,'Version'))
+   fseek(FileInfo.FileId,0,'bof');
+   Data=fread(FileInfo.FileId,2,'uint32');
+   if ((Data(1)<10000)&&(Data(2)<=64))
+      FileInfo.Version='BestMatchIsVD';
+   else
+      FileInfo.Version='BestMatchIsVB';
+   end
+end
+if (~isempty(findstr(lower(FileInfo.Version),'vb')))
+   FileInfo.IsVB=1;
+   FileInfo.IsVD=0;
+elseif (~isempty(findstr(lower(FileInfo.Version),'vd')))
+   FileInfo.IsVB=0;
+   FileInfo.IsVD=1;
+elseif (~isempty(findstr(lower(FileInfo.Version),'ve')))
+   FileInfo.IsVB=0;
+   FileInfo.IsVD=1;
+else
+   error('jGetFileInfo(): Unknown version');
+end
+
+% Find how many measurements are in the file
+if (FileInfo.IsVB)
+   fseek(FileInfo.FileId,0,'bof');
+   FileInfo.Header.StartPosition=0;
+   FileInfo.Header.EndPosition=FileSize;
+   FileInfo.Header.DataPosition=fread(FileInfo.FileId,1,'uint32');
+elseif (FileInfo.IsVD)
+   fseek(FileInfo.FileId,4,'bof');
+   NumberOfMeasurements=fread(FileInfo.FileId,1,'uint32');
+   for MeasIndex=1:NumberOfMeasurements
+      FileInfo.Header(MeasIndex).MeasId=fread(FileInfo.FileId,1,'uint32');
+      FileInfo.Header(MeasIndex).FileId=fread(FileInfo.FileId,1,'uint32');
+      FileInfo.Header(MeasIndex).StartPosition=fread(FileInfo.FileId,1,'uint64');
+      FileInfo.Header(MeasIndex).EndPosition=FileInfo.Header(MeasIndex).StartPosition+fread(FileInfo.FileId,1,'uint64');
+      FileInfo.Header(MeasIndex).PatientName=sprintf('%s',fread(FileInfo.FileId,64,'uchar=>char'));
+      FileInfo.Header(MeasIndex).ProtocolName=sprintf('%s',fread(FileInfo.FileId,64,'uchar=>char'));
+   end
+   for MeasIndex=1:NumberOfMeasurements
+      if (fseek(FileInfo.FileId,FileInfo.Header(MeasIndex).StartPosition,'bof'))
+         error('jGetFileInfo(): Data set not complete');
+      end
+      FileInfo.Header(MeasIndex).DataPosition=FileInfo.Header(MeasIndex).StartPosition+fread(FileInfo.FileId,1,'uint32');
+   end
+else
+   error('jGetFileInfo(): Unknown file type');
+end
+
+% Load all protocols
+FileInfo.Protocol=jGetProtocol(FileInfo,PrintHeader);
+
+
+% --------------------------------------------------------------------------------
+% FileInfo=jLoadBasicProtocol(FileName)
+% Jason Mendes - UCAIR - University of Utah - 2015
+% --------------------------------------------------------------------------------
+% This function opens the .dat file and retrieves information about the sequence
+% protocol from the ASCCONV section and some additional parameters.
+% --------------------------------------------------------------------------------
+function Protocol=jGetProtocol(FileInfo,PrintHeader)
+
+% Prepare to read protocol
+Protocol=[];
+
+% There are some useful parameters not in the ASCCONV section
+ParameterTag(1).String='<ParamLong."lNoOfPhaseCorrScans">';
+ParameterTag(2).String='<ParamLong."relSliceNumber">';
+ParameterTag(3).String='<ParamLong."NSetMeas">';
+ParameterTag(4).String='<ParamLong."RampupTime">';
+ParameterTag(5).String='<ParamLong."FlattopTime">';
+ParameterTag(6).String='<ParamLong."DelaySamplesTime">';
+ParameterTag(7).String='<ParamLong."RegridMode">';
+ParameterTag(8).String='<ParamDouble."ADCDuration">';
+ParameterTag(9).String='<ParamLong."alRegridRampupTime">';
+ParameterTag(10).String='<ParamLong."alRegridFlattopTime">';
+ParameterTag(11).String='<ParamLong."alRegridDelaySamplesTime">';
+ParameterTag(12).String='<ParamLong."alRegridMode">';
+ParameterTag(13).String='<ParamDouble."aflRegridADCDuration">';
+ParameterTag(14).String='<ParamLong."NoOfFourierPartitions">';
+ParameterTag(15).String='<ParamString."PatientPosition">';
+
+ParameterTag(16).String='<ParamString."PatientBirthDay">';
+
+% Find protocol for each requested sequence
+for SearchIndex=1:length(FileInfo.Header)
+   % Read in the header
+   HeaderStart=FileInfo.Header(SearchIndex).StartPosition;
+   HeaderEnd=FileInfo.Header(SearchIndex).DataPosition;
+   if (fseek(FileInfo.FileId,HeaderStart,'bof'))
+      error('jGetProtocol(): Data header not complete');
+   end
+   Header=fread(FileInfo.FileId,HeaderEnd-HeaderStart,'char=>char')';
+   
+%    %Svedin: Start
+%    if PrintHeader
+%        fhid = fopen([FileInfo.FileName(1:end-4) '_hdr.txt'], 'w');
+%        fprintf(fhid, '%c', Header);
+%        fclose(fhid);
+%    end
+%    %Svedin: End
+   
+   % Find ASCCONV section
+   StartIndex=max(findstr(Header,'ASCCONV BEGIN'));
+   EndIndex=max(findstr(Header,'ASCCONV END'));
+   if ((~isempty(StartIndex))&&(~isempty(EndIndex)))
+      String=Header(StartIndex:EndIndex);
+      String(find(String==';'))=':'; % Remove original ';'
+      String=regexprep(String,'\n',';\n');
+      String=String((find(String==10,1)+1):find(String==10,1,'last'));
+      String(find(String<=32))=[]; % Remove spaces
+      String(find(String=='_'))=[]; % '_' cause problems
+      String=regexprep(String,'[','('); % Matlab uses round brackets for indices
+      String=regexprep(String,']',')'); % Matlab uses round brackets for indices
+      String=regexprep(String,'"',''''); % Matlab uses round brackets for indices
+      String=regexprep(String,'(','(1+'); % Matlab is not zero based
+      String=regexprep(String,'0x(\w*)','hex2dec(''$1'')'); % Convert hex values
+      LineEnd=[0 find(String==';')];
+      for Index=2:length(LineEnd)
+         EvalString=String((LineEnd(Index-1)+1):LineEnd(Index));
+         if isempty(findstr(lower(EvalString),'attribute'))
+            try
+               eval(sprintf('Protocol(%d).%s',SearchIndex,EvalString));
+            catch
+               fprintf('Error adding %s\n',EvalString');
+            end
+         end
+      end
+   end   
+   % Read in extra parameters
+   for Index=1:length(ParameterTag);
+      StartIndex=min(findstr(Header,ParameterTag(Index).String));
+      EndIndex=find(Header(StartIndex:end)=='}',1);
+      if ((~isempty(StartIndex))&&(~isempty(EndIndex)))
+         CurrentString=Header((1:EndIndex)+StartIndex);
+         NameIndex=find(CurrentString=='"',2);
+         ValueIndex=(find(CurrentString=='{',1,'last')+1):(find(CurrentString=='}',1,'last')-1);
+         if (length(NameIndex==2)&&length(ValueIndex>0))
+            NameString=CurrentString((NameIndex(1)+1):(NameIndex(2)-1));
+            ValueString=CurrentString(ValueIndex);
+            if (~isempty(findstr(lower(CurrentString),'double')))
+               ValueString=ValueString((min(findstr(lower(ValueString),'<precision>'))+12):end);
+               if (~isempty(find(ValueString==10,1)))
+                   ValueString=ValueString((find(ValueString==10,1)+1):end);
+               end
+               ValueString=sprintf('%s',ValueString(find(ValueString<=32,1):end));
+            elseif (~isempty(findstr(lower(CurrentString),'long')))
+               ValueString=sprintf('%s',ValueString);
+            elseif (~isempty(findstr(lower(CurrentString),'string')))
+               if (length(find(ValueString=='"'))<2)
+                  ValueString='''''';
+               else
+                  ValueString(find(ValueString=='"'))='''';
+               end
+            else
+               % Not supported at this time
+               ValueString='[]';
+            end
+            EvalString=sprintf('Protocol(%d).%s=[%s];',SearchIndex,NameString,ValueString);
+            EvalString(find(EvalString==10))=32;
+            try
+               eval(EvalString);
+            catch
+               fprintf('Error %s\n',EvalString');
+               pause;
+            end
+         end
+      end
+   end
+   % Compatibility issues
+    if (isfield(Protocol(SearchIndex),'ADCDuration'))
+        if (~isempty(Protocol(SearchIndex).ADCDuration))
+            Protocol(SearchIndex).aflRegridADCDuration=Protocol(SearchIndex).ADCDuration;
+        end
+    end
+    if (isfield(Protocol(SearchIndex),'RampupTime'))
+        if (~isempty(Protocol(SearchIndex).RampupTime))
+            Protocol(SearchIndex).alRegridRampupTime=Protocol(SearchIndex).RampupTime;
+        end
+    end
+    if (isfield(Protocol(SearchIndex),'FlattopTime'))
+        if (~isempty(Protocol(SearchIndex).FlattopTime))
+            Protocol(SearchIndex).alRegridFlattopTime=Protocol(SearchIndex).FlattopTime;
+        end
+    end
+    if (isfield(Protocol(SearchIndex),'DelaySamplesTime'))
+        if (~isempty(Protocol(SearchIndex).DelaySamplesTime))
+            Protocol(SearchIndex).alRegridDelaySamplesTime=Protocol(SearchIndex).DelaySamplesTime;
+        end
+    end
+    if (isfield(Protocol(SearchIndex),'RegridMode'))
+        if (~isempty(Protocol(SearchIndex).RegridMode))
+            Protocol(SearchIndex).alRegridMode=Protocol(SearchIndex).RegridMode;
+        end
+    end
+    if (isfield(Protocol(SearchIndex),'sWiPMemBlock'))
+        if (~isempty(Protocol(SearchIndex).sWiPMemBlock))
+            Protocol(SearchIndex).sWipMemBlock=Protocol(SearchIndex).sWiPMemBlock;
+        end
+    end
+   % Fix problem with partition count for 2D
+   if (isfield(Protocol(SearchIndex),'sKSpace'))
+      if (Protocol(SearchIndex).sKSpace.ucDimension<3)
+         Protocol(SearchIndex).sKSpace.lPartitions=1;
+      end
+   end
+   % Single repetition is not recorded
+   if (~isfield(Protocol(SearchIndex),'lRepetitions'))
+      Protocol(SearchIndex).lRepetitions=0;
+   end
+   if (isempty(Protocol(SearchIndex).lRepetitions))
+       Protocol(SearchIndex).lRepetitions=0;
+   end      
+    % Number of coils
+    if (isfield(Protocol(SearchIndex),'sCoilSelectMeas'))
+        Protocol(SearchIndex).asCoilSelectMeas=Protocol(SearchIndex).sCoilSelectMeas;
+    end
+    if (isfield(Protocol(SearchIndex),'asCoilSelectMeas'))
+        if (FileInfo.IsVB)
+            Protocol(SearchIndex).lNumberOfChannels=length(Protocol(SearchIndex).asCoilSelectMeas(1).asList);
+        elseif (FileInfo.IsVD)
+            Protocol(SearchIndex).lNumberOfChannels=length(Protocol(SearchIndex).sCoilSelectMeas(1).aRxCoilSelectData(1).asList);
+        end
+    end
+   % Find location of PMU and image lines
+   if (FileInfo.IsVB)
+      fseek(FileInfo.FileId,FileInfo.Header(SearchIndex).DataPosition,'bof');
+      Data=fread(FileInfo.FileId,3,'uchar=>uchar');
+      LengthDMA=double(typecast([Data(1:3);0],'uint32'));
+      Protocol(SearchIndex).OffsetPMU=[];
+      Protocol(SearchIndex).OffsetImage=(FileInfo.Header(SearchIndex).DataPosition): LengthDMA:(FileInfo.Header(SearchIndex).EndPosition-LengthDMA);
+   elseif (FileInfo.IsVD)
+      for LoopIndex=1:2
+         CountPMU=0;
+         CountImage=0;
+         CurrentPosition=FileInfo.Header(SearchIndex).DataPosition;
+         while (CurrentPosition<=(FileInfo.Header(SearchIndex).EndPosition-192))
+            fseek(FileInfo.FileId,CurrentPosition,'bof');
+            Data=fread(FileInfo.FileId,3,'uchar=>uchar');
+            LengthDMA=double(typecast([Data(1:3);0],'uint32'));
+            fseek(FileInfo.FileId,CurrentPosition+40,'bof');
+            Data=fread(FileInfo.FileId,4,'uchar=>uchar');
+            Mask=double(typecast(Data,'uint32'));
+            if (min(bitand(Mask,2^5),1))
+               CountPMU=CountPMU+1;
+               if (LoopIndex==2)
+                  Protocol(SearchIndex).OffsetPMU(CountPMU)=CurrentPosition;
+               end
+            else
+               if (LengthDMA>(Protocol(SearchIndex).lNumberOfChannels*32+192))
+                  CountImage=CountImage+1;
+                  if (LoopIndex==2)
+                     Protocol(SearchIndex).OffsetImage(CountImage)=CurrentPosition;
+                  end
+               end
+            end
+            CurrentPosition=CurrentPosition+LengthDMA;
+         end
+         if (LoopIndex==1)
+            Protocol(SearchIndex).OffsetPMU=zeros(1,CountPMU);
+            Protocol(SearchIndex).OffsetImage=zeros(1,CountImage);
+         end
+      end
+   end
+   % Get readout length
+   
+end
+
+
+% --------------------------------------------------------------------------------
+% Data=jReadSimpleString(FileInfo,InitialString)
+% Jason Mendes - UCAIR - University of Utah - 2014
+% Update: Returns both data string name and value (October 2015)
+% --------------------------------------------------------------------------------
+% This function reads in a string parameter value from a .dat file.
+% Returns Data.Name and Data.String containing the string name and value.
+% --------------------------------------------------------------------------------
+function Data=jReadSimpleString(FileInfo,InitialString)
+
+% Read in data until first closing bracket is found
+FinalString=InitialString;
+Data=[];
+while (isempty(find(FinalString=='}',1)))
+   NextString=fgets(FileInfo.FileId,1000);
+   FinalString=sprintf('%s %s',FinalString,NextString);
+end
+
+% Get field name
+ValueIndex=find(FinalString=='"',2,'first');
+if (length(ValueIndex)<2)
+   DataName=sprintf('UnknownName%d',round(rand(1)*1000));
+else
+   DataName=FinalString(ValueIndex(1)+1:ValueIndex(2)-1);
+end
+DataName(find(DataName<33))=[]; % Ignore line feeds, etc...
+
+% Get the values
+ValueIndex=find(FinalString=='{',1,'last')+1:find(FinalString=='}',1,'last')-1;
+StringText=FinalString(ValueIndex);
+ValueIndex=find(StringText=='"',2,'first');
+if (length(ValueIndex)<2)
+   DataString='Error';
+else
+   DataString=StringText(ValueIndex(1)+1:ValueIndex(2)-1);
+end
+
+% Return values
+Data.Name=DataName;
+Data.String=DataString;

--- a/matlab/read_kspace_dependencies/mapVBVD/AcqTime.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/AcqTime.m
@@ -1,0 +1,59 @@
+function [Time, StrTime] = AcqTime(hdr, Str)
+%added by Dylan E. Palomino
+%the Siemens time stamps are converted (to hour:minute:second format) and exported as strings to put in "shd.ulAcquisitionStrTimeStamp"
+SecTot = double(hdr.ulTimeStamp)*0.0025; % In Seconds
+MinTot = SecTot/60;
+HrTot = MinTot/60;
+Hr = HrTot-mod(HrTot,1);
+MinRem = mod(HrTot,1)*60;
+Min = MinRem-mod(MinRem,1);
+SecRem = mod(MinRem,1)*60;
+Sec = SecRem-mod(SecRem,1);
+Sec1 = round(mod(SecRem,1),2);
+Time(:,1) = Hr;
+Time(:,2) = Min;
+Time(:,3) = SecRem;
+if Str == 1
+    StrHr = num2str(Hr);
+    for j = 1:length(StrHr)
+        if StrHr(j,1) == ' '
+            StrHr(j,1) = '0';
+        end
+        if size(StrHr,2) == 1 % DEP 02/01/19
+            StrHr(:,2) = StrHr(:,1); 
+            StrHr(:,1) = '0';
+        end 
+    end
+    StrMin = num2str(Min);
+    for j = 1:length(StrMin)
+        if StrMin(j,1) == ' '
+            StrMin(j,1) = '0';
+        end
+    end
+     StrSec = num2str(SecRem,'%0.4f');
+    for j = 1:length(StrSec)
+        if StrSec(j,1) == ' '
+            StrSec(j,1) = '0';
+        end
+    end
+    for j = 1:length(Time)
+        StrTime(j,:) = [StrHr(j,:), ':', StrMin(j,:), ':', StrSec(j,:)];
+    end
+end
+% TimeStr = num2str(Time);
+% for j = 1:length(SecTot)
+%     StrHr(j) = num2str(Hr(j));
+%     StrMin = num2str(Min);
+%     StrSec = num2str(Sec);
+%     if length(StrHr) == 1
+%         StrHr = ['0',StrHr]
+%     end
+%     if length(StrMin) == 1
+%         StrMin = ['0',StrMin];
+%     end
+%     if length(StrSec) == 1
+%         StrSec = ['0',StrSec];
+%     end
+%     Time(j,:) = [StrHr,':',StrMin,':',StrSec];
+% end
+end

--- a/matlab/read_kspace_dependencies/mapVBVD/getshd.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/getshd.m
@@ -1,0 +1,130 @@
+%function [ RawData, shd ] = getshd( twix_obj_1,twix_obj_end,shd,par )
+function [ shd ] = getshd( twix_obj_1,twix_obj_end,shd,par )
+%UNTITLED Summary of this function goes here
+%getshd: gets the short header variables from the open file
+%   Detailed explanation goes here
+    shd.foundnoise = 0;
+    try
+        shd.noise1 = double(twix_obj_1.noise{''});
+        shd.dimvn1 = twix_obj_1.noise.sqzDims;
+        shd.foundnoise = 1;
+    catch
+        disp('no noise scan in this data in twix_obj{1, 1}');
+    end
+    try
+        shd.noise2 = double(twix_obj_end.noise{''});
+        shd.dimvn2 = twix_obj_end.noise.sqzDims;
+        shd.foundnoise = shd.foundnoise + 2;
+    catch
+        disp('no noise scan in this data in twix_obj_end');
+    end
+    %RawData = double(twix_obj_end.image{''});  %VB17. HOD Commented out
+shd.dimv = lower(twix_obj_end.image.sqzDims);
+shd.ncol = twix_obj_end.image.NCol;
+shd.nch = twix_obj_end.image.NCha;
+shd.nlin = twix_obj_end.image.NLin;
+shd.npar = twix_obj_end.image.NPar;
+shd.nsli = twix_obj_end.image.NSli;
+shd.nav = twix_obj_end.image.NAve;
+shd.nphs = twix_obj_end.image.NPhs;
+shd.neco = twix_obj_end.image.NEco;
+shd.nrep = twix_obj_end.image.NRep;
+shd.nset = twix_obj_end.image.NSet;
+
+
+          
+shd.coils = cell(shd.nch);
+shd.Txfrequency = twix_obj_end.hdr.MeasYaps.sTXSPEC.asNucleusInfo{1, 1}.lFrequency;  
+shd.Txfrequency1 = twix_obj_1.hdr.MeasYaps.sTXSPEC.asNucleusInfo{1, 1}.lFrequency;  
+shd.TxfreqDicom = twix_obj_end.hdr.Dicom.lFrequency;  
+shd.TxfreqDicom1 = twix_obj_1.hdr.Dicom.lFrequency;  
+shd.TxfreqPheonix = twix_obj_end.hdr.Phoenix.sTXSPEC.asNucleusInfo{1, 1}.lFrequency;  
+shd.TxfreqPheonix1 = twix_obj_1.hdr.Phoenix.sTXSPEC.asNucleusInfo{1, 1}.lFrequency;  
+shd.TR=twix_obj_end.hdr.Config.TR/1000;    %TR in ms
+shd.contrasts = twix_obj_end.hdr.MeasYaps.lContrasts;  %should be number of echoes
+shd.etl = twix_obj_end.hdr.MeasYaps.sFastImaging.lEPIFactor;           %lTurboFactor;       %Dicom.EchoTrainLength;
+%shd.EchoSpacing    = twix_obj_end.hdr.Meas.lEchoSpacing;
+shd.TE=twix_obj_end.hdr.MeasYaps.alTE{1,1}/1000; % TE in ms
+vvv = cell2mat(twix_obj_end.hdr.MeasYaps.alTE);
+shd.TEv= vvv(1,1:shd.contrasts)/1000; % TE in ms
+shd.phaseFOV = twix_obj_end.hdr.Config.PhaseFoV;
+shd.readoutFOV = twix_obj_end.hdr.Config.ReadFoV;
+shd.sliceFOV = twix_obj_end.hdr.MeasYaps.sSliceArray.asSlice{1,1}.dThickness; %Attention currently it is assumed that all slices have same thickness
+shd.BaseResolution = twix_obj_end.hdr.MeasYaps.sKSpace.lBaseResolution;
+shd.PhaseRes = twix_obj_end.hdr.MeasYaps.sKSpace.lPhaseEncodingLines;
+shd.PhaseNlines= twix_obj_end.hdr.MeasYaps.sKSpace.lPhaseEncodingLines;
+shd.nslice = twix_obj_end.hdr.MeasYaps.sSliceArray.lSize;
+          if(shd.npar > shd.nslice)         %probably should be whether shd.do3D is set or 'par' is set
+              shd.SliceRes = shd.npar;
+          else
+              shd.SliceRes = shd.nslice;
+          end
+          shd.AccelFactPE = twix_obj_end.hdr.MeasYaps.sPat.lAccelFactPE;
+          shd.dograppa = 0;
+          if(shd.AccelFactPE > 1)
+              shd.dograppa = 1;
+              shd.noise2 = double(twix_obj_end.noise{''});
+              shd.refscan = double(twix_obj_end.refscan{''});
+              shd.dimvref = lower(twix_obj_end.refscan.sqzDims);
+          end
+
+cearray = repmat('aaa',[shd.nch,1]);
+iadc = zeros(shd.nch,1);
+try         %DLP 4/19/19 changed below to handle VB17 body coil
+    aaa = char(twix_obj_end.hdr.MeasYaps.asCoilSelectMeas{1}.asList{jch}.sCoilElementID.tElement);
+    for jch = 1:shd.nch
+        aaa = char(twix_obj_end.hdr.MeasYaps.asCoilSelectMeas{1}.asList{jch}.sCoilElementID.tElement);
+        [~,nchar] = size(aaa);
+        nchce = min([nchar,3]);
+        cearray(jch,1:nchce) = aaa(1,1:nchce);
+    end
+catch ME
+    ME.message
+    for jch = 1:shd.nch
+        aaa = char(twix_obj_end.hdr.MeasYaps.sCoilSelectMeas.aRxCoilSelectData{1, 1}.asList{jch}.sCoilElementID.tElement);
+        iadc(jch) = twix_obj_end.hdr.MeasYaps.sCoilSelectMeas.aRxCoilSelectData{1, 1}.asList{jch}.lADCChannelConnected;
+        [~,nchar] = size(aaa);
+        if length(aaa)==2 %% HOD 2020-20-30
+            cearray(jch,1:2) = aaa(1,1:2);
+        else
+            cearray(jch,:) = aaa(1,1:3);
+        end
+        if(nchar>3) cearray(jch,:) = aaa(1,2:4);end
+    end
+end
+[iadcs,jind] = sort(iadc);
+shd.ce = char(cearray(jind,:));
+
+shd.B0      = twix_obj_end.hdr.Dicom.flMagneticFieldStrength;
+shd.FA      = twix_obj_end.hdr.MeasYaps.adFlipAngleDegree{1,1};
+shd.txamp   = twix_obj_end.hdr.Dicom.flTransRefAmpl;
+try shd.txampNL = twix_obj_end.hdr.MeasYaps.sTXSPEC.aRFPULSE{1,1}.flAmplitude; end
+shd.TXSPEC_RFPULSE_all = twix_obj_end.hdr.MeasYaps.sTXSPEC.aRFPULSE;
+shd.ntime   = shd.nrep * shd.nav;
+shd.dim     = twix_obj_end.hdr.Dicom.tMRAcquisitionType; % HOD
+try
+    shd.nbaseline = twix_obj_end.hdr.MeasYaps.sWipMemBlock.alFree{1,3}  ;
+    shd.wipmemblock = twix_obj_end.hdr.MeasYaps.sWipMemBlock.alFree{1,:}  ;
+catch
+    shd.nbaseline = 1;
+    shd.wipmemblock = [0,0];
+end
+%shd.wipmemblock = twix_obj_end.hdr.MeasYaps.sWipMemBlock.alFree{1,3}  ;
+%get the array variables for time stamps:
+shd.dwellTime = twix_obj_end.hdr.MeasYaps.sRXSPEC.alDwellTime{1} ;
+%shd.rbw = 1e9 ./ (size(RawData,1)*twix_obj_end.hdr.MeasYaps.sRXSPEC.alDwellTime{1}) ; % HOD Commented out
+shd.rbw     = 1e9 ./ ((shd.ncol)*twix_obj_end.hdr.MeasYaps.sRXSPEC.alDwellTime{1}) ; % Use nCol instead of size(RawData,1)
+shd.EchoSpacing = 1/shd.rbw; % Correct?!
+shd.ulTimeStamp = twix_obj_end.hdr.ulTimeStamp; % DEP 01/08/19
+shd.ulAcquisitionTimeStamp = twix_obj_end.hdr.ulAcquisitionTimeStamp; % DEP 01/08/19
+shd.ulAcquisitionStrTimeStamp = twix_obj_end.hdr.ulAcquisitionStrTimeStamp; % DEP 01/08/19
+shd.lTotalScanTimeSec = twix_obj_end.hdr.MeasYaps.lTotalScanTimeSec; % DEP 01/08/19
+try
+    %shd.Tnav1 = twix_obj_end.hdr.MeasYaps.sWipMemBlock.alFree{par.jindTEnav1};       %navigator TE1 in us   
+    %shd.Tnav2 = twix_obj_end.hdr.MeasYaps.sWipMemBlock.alFree{par.jindTEnav2};       %navigator TE2 in us
+catch ME
+    ME.message
+end
+
+end
+

--- a/matlab/read_kspace_dependencies/mapVBVD/mapVBVD.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/mapVBVD.m
@@ -1,0 +1,822 @@
+function twix_obj = mapVBVD(filename,varargin)
+
+%  Reads Siemens raw .dat file from VB/VD MRI raw data.
+% 
+%  Requires twix_map_obj_uk.m
+% 
+%  Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de)
+% 
+% 
+%  Philipp Ehses 11.02.07, original version
+%  [..]
+%  Philipp Ehses 22.03.11, port to VD11
+%  Felix Breuer  31.03.11, added support for noise & ref scans, speed fixes
+%  Philipp Ehses 19.08.11, complete reorganization of code, added
+%                          siemens_data_obj class to improve readability
+%  Wolf Blecher  15.05.12, readout of slice position parameters for VB Data sets
+%  Wolf Blecher  11.06.12, added distinction between PATREF and PATREF PHASCOR
+%  Philipp Ehses 02.08.12, again massive code reorganization. The new class
+%                          twix_map_obj.m now stores the memory position of
+%                          each dataset (coils are included - size: NCol*NCha)
+%                          The actual data is not read until it is demanded
+%                          by a "data_obj()" call. This makes it possible
+%                          to selectively read in only parts of the data
+%                          (e.g. to preserve memory).
+%  Philipp Ehses 27.08.12, speed optimizations (avoiding of .-subsref calls)
+%  07.09.12 Thanks to Stephen Yutzy for implementing support for raw data
+%           correction (currently only supported for VB software version).
+%  15.01.13 Thanks to Zhitao Li for proper handling of SYNCDATA.
+%  Philipp Ehses 28.08.13, added support for VD13 multi-raid files
+%  Michael Völker May-Aug 15 * Better error tolerance with incomplete files.
+%                          * Swapped out parsing loop into a separate function
+%                            without access to twix object (no thousands of subsref calls).
+%                          * For parsing, use an as-minimalistic-as-possible loop
+%                            to gather all mdhs in binary form. They are all stored
+%                            in one array "mdh_blob".
+%                          * Translation of mdhs from binary to struct is vectorized 
+%                            and almost instant. It's done in evalMDH(), replacing
+%                            evalMDHvb() and evalMDHvd(), no more freads inside!
+%                          * vectorized readMDH(), quasi-instant
+%                          * When parsing, actually read the entire file without jumps.
+%                            This is weirdly faster than fseek(), plus the entire file is
+%                            kept in the file system cache, if possible. Next read
+%                            is therefore faster, too.
+%                          * => Parsing speed improved by factor 3...7 or so
+%                          * Speed increase for reading data, esp. when slicing,
+%                            os-removal or reflected lines. Also for random acquisitions.
+% 
+% 
+% Input:
+% 
+% filename or simply meas. id, e.g. mapVBVD(122) (if file is in same path)
+% optional arguments (see below)
+% 
+% Output: twix_obj structure with elements (if available):
+%     .image:         image scan
+%     .noise:         for noise scan
+%     .phasecor:      phase correction scan
+%     .phasestab:     phase stabilization scan
+%     .phasestabRef0: phase stab. ref. (MDH_REFPHASESTABSCAN && !MDH_PHASESTABSCAN)
+%     .phasestabRef1: phase stab. ref. (MDH_REFPHASESTABSCAN &&  MDH_PHASESTABSCAN)
+%     .refscan:       parallel imaging reference scan
+%     .refscanPC:     phase correction scan for reference data
+%     .refscanPS:     phase stabilization scan for reference data
+%     .refscanPSRef0: phase stab. ref scan for reference data
+%     .refscanPSRef1: phase stab. ref scan for reference data
+%     .RTfeedback:    realtime feedback data
+%     .vop:           vop rf data
+% 
+% 
+% The raw data can be obtained by calling e.g. twix_obj.image() or for
+% squeezed data twix_obj.image{''} (the '' are needed due to a limitation
+% of matlab's overloading capabilities).
+% Slicing is supported as well, e.g. twix_obj.image(:,:,1,:) will return
+% only the first line of the full data set (all later dimensions are
+% squeezed into one). Thus, slicing of the "memory-mapped" data objects
+% works exactly the same as regular matlab array slicing - with one
+% exception:
+% The keyword 'end' is not supported.
+% Overloading of the '()' and '{}' operators works by overloading matlab's
+% built-in 'subsref' function. Matlab calls subsref whenever the operators
+% '()', '{}', or '.' are called. In the latter case, the overloaded subsref
+% just calls the built-in subsref function since we don't want to change
+% the behaviour for '.'-calls. However, this has one minor consequence:
+% There's no way (afaik) to know whether the original call was terminated
+% with a semicolon. Thus, a call to e.g. twix_obj.image.NLin will produce
+% no output with or without semicolon termination. 'a = twix_obj.image.NLin'
+% will however produce the expected result.
+% 
+% 
+% Order of raw data:
+%  1) Columns
+%  2) Channels/Coils
+%  3) Lines
+%  4) Partitions
+%  5) Slices
+%  6) Averages
+%  7) (Cardiac-) Phases
+%  8) Contrasts/Echoes
+%  9) Measurements
+% 10) Sets
+% 11) Segments
+% 12) Ida
+% 13) Idb
+% 14) Idc
+% 15) Idd
+% 16) Ide
+% 
+% 
+% Optional parameters/flags:
+% 
+% removeOS:          removes oversampling (factor 2) in read direction
+% doAverage:         performs average (resulting avg-dim has thus size 1)
+% ignoreSeg:         ignores segment mdh index (works basically the same as
+%                    the average flag)
+% rampSampRegrid     optional on-the-fly regridding of ramp-sampled readout
+% doRawDataCorrect:  enables raw data correction if used in the acquisition
+%                    (only works for VB atm)
+% 
+% These flags can also be set/unset later, e.g "twix_obj.image.flagRemoveOS = 1"
+% 
+% 
+% Examples:
+%   twix_obj = mapVBVD(measID);
+% 
+%   % return all image-data:
+%   image_data = twix_obj.image();
+%   % return all image-data with all singular dimensions removed/squeezed:
+%   image_data = twix_obj.image{''}; % '' necessary due to a matlab limitation
+%   % return only data for line numbers 1 and 5; all dims higher than 4 are
+%   % grouped into dim 5):
+%   image_data = twix_obj.image(:,:,[1 5],:,:);
+%   % return only data for coil channels 2 to 6; all dims higher than 4 are
+%   % grouped into dim 5); but work with the squeezed data order
+%   % => use '{}' instead of '()':
+%   image_data = twix_obj.image{:,2:6,:,:,:};
+% 
+%   So basically it works like regular matlab array slicing (but 'end' is
+%   not supported; note that there are still a few bugs with array slicing).
+% 
+%   % NEW: unsorted raw data (in acq. order):
+%   image_data = twix_obj.image.unsorted(); % no slicing supported atm
+% 
+% 
+% Suppress silly editor warnings in the entire file, barking about
+% unused variables:
+%#ok<*NASGU>
+
+if ~exist('filename','var') || isempty(filename)
+    info = 'Please select binary file to read';
+    [fname,pathname]=uigetfile('*.dat',info);
+    if isempty(pathname)
+        return
+    end
+    filename=[pathname fname];
+else
+    if ischar(filename)
+        % assume that complete path is given
+        if  ~strcmpi(filename(end-3:end),'.dat');
+            filename=[filename '.dat'];   %% adds filetype ending to file
+        end
+    else
+        % filename not a string, so assume that it is the MeasID
+        measID   = filename;
+        filelist = dir('*.dat');
+        filesfound = 0;
+        for k=1:numel(filelist)
+            if regexp(filelist(k).name,['^meas_MID0*' num2str(measID) '_.*\.dat'])==1
+                if filesfound == 0
+                    filename = filelist(k).name;
+                end
+                filesfound = filesfound+1;
+            end
+        end
+        if filesfound == 0
+            error(['File with meas. id ' num2str(measID) ' not found.']);
+        elseif filesfound > 1
+            disp(['Multiple files with meas. id ' num2str(measID) ' found. Choosing first occurence.']);
+        end
+    end
+end
+
+% add absolute path, when no path is given
+[pathstr, name, ext] = fileparts(filename);
+
+if isempty(pathstr)
+    pathstr  = pwd;
+    filename = fullfile(pathstr, [name ext]);
+end
+
+%%%%% Parse varargin %%%%%
+arg.bReadImaScan    = true;
+arg.bReadNoiseScan  = true;
+arg.bReadPCScan     = true;
+arg.bReadRefScan    = true;
+arg.bReadRefPCScan  = true;
+arg.bReadRTfeedback = true;
+arg.bReadPhaseStab  = true;
+arg.bReadHeader     = true;
+
+k=1;
+while k <= numel(varargin)
+
+    if ~ischar(varargin{k})
+        error('string expected');
+    end
+
+    switch lower(varargin{k})
+        case {'readheader','readhdr','header','hdr'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.bReadHeader = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.bReadHeader = true;
+                k = k+1;
+            end
+        case {'removeos','rmos'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.removeOS = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.removeOS = true;
+                k = k+1;
+            end
+        case {'doaverage','doave','ave','average'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doAverage = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doAverage = true;
+                k = k+1;
+            end
+        case {'averagereps','averagerepetitions'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageReps = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageReps = true;
+                k = k+1;
+            end
+        case {'averagesets'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageSets = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageSets = true;
+                k = k+1;
+            end
+        case {'ignseg','ignsegments','ignoreseg','ignoresegments'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.ignoreSeg = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.ignoreSeg = true;
+                k = k+1;
+            end
+        case {'rampsampregrid','regrid'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.rampSampRegrid = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.rampSampRegrid = true;
+                k = k+1;
+            end
+        case {'rawdatacorrect','dorawdatacorrect'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doRawDataCorrect = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doRawDataCorrect = true;
+                k = k+1;
+            end
+        otherwise
+            error('Argument not recognized.');
+    end
+end
+clear varargin
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+tic;
+fid = fopen(filename,'r','l','US-ASCII');
+
+% start of actual measurement data (sans header)
+fseek(fid,0,'bof');
+
+firstInt  = fread(fid,1,'uint32');
+secondInt = fread(fid,1,'uint32');
+
+% lazy software version check (VB or VD?)
+if and(firstInt < 10000, secondInt <= 64)
+    version = 'vd';
+    disp('Software version: VD (!?)');
+
+    % number of different scans in file stored in 2nd in
+    NScans = secondInt;
+    measID = fread(fid,1,'uint32');
+    fileID = fread(fid,1,'uint32');
+    % measOffset: points to beginning of header, usually at 10240 bytes
+    measOffset = fread(fid,1,'uint64');
+    measLength = fread(fid,1,'uint64');
+    fseek(fid,measOffset,'bof');
+    hdrLength  = fread(fid,1,'uint32');
+
+else
+    % in VB versions, the first 4 bytes indicate the beginning of the
+    % raw data part of the file
+    version  = 'vb';
+    disp('Software version: VB (!?)');
+    measOffset = 0;
+    hdrLength  = firstInt;
+    NScans     = 1; % VB does not support multiple scans in one file
+end
+datStart = measOffset + hdrLength;
+
+%SRY read data correction factors
+% do this for all VB datasets, so that the factors are available later
+% in the image_obj if the user chooses to set the correction flag
+if (strcmp(version, 'vb')) % not implemented/tested for vd, yet
+    frewind(fid);
+    while ( (ftell(fid) < datStart) && ~exist('rawfactors', 'var'))
+        line = fgetl(fid);
+        %find the section of the protocol
+        %note: the factors are also available in <ParamArray."CoilSelects">
+        %along with element name and FFT scale, but the parsing is
+        %significantly more difficult
+        if (~isempty(strfind(line, '<ParamArray."axRawDataCorrectionFactor">')))
+            while (ftell(fid) < datStart)
+                line = fgetl(fid);
+                %find the line with correction factors
+                %the factors are on the first line that begins with this
+                %pattern
+                if (~isempty(strfind(line, '{ {  { ')))
+                    line = strrep(line, '}  { } ', '0.0');
+                    line = strrep(line, '{', '');
+                    line = strrep(line, '}', '');
+                    rawfactors = textscan(line, '%f');
+                    rawfactors = rawfactors{1}; %textscan returns a 1x1 cell array
+                    % this does not work in this location because the MDHs
+                    % have not been parsed yet
+                    %                    if (length(rawfactors) ~= 2*max(image_obj.NCha))
+                    %                       error('Number of raw factors (%f) does not equal channel count (%d)', length(rawfactors)/2, image_obj.NCha);
+                    %                    end;
+                    if (mod(length(rawfactors),2) ~= 0)
+                        error('Error reading rawfactors');
+                    end;
+                    %note the transpose, this makes the vector
+                    %multiplication during the read easier
+                    arg.rawDataCorrectionFactors = rawfactors(1:2:end).' + 1i*rawfactors(2:2:end).';
+                    break;
+                end
+            end
+        end
+    end
+    disp('Read raw data correction factors');
+end
+
+% data will be read in two steps (two while loops):
+%   1) reading all MDHs to find maximum line no., partition no.,... for
+%      ima, ref,... scan
+%   2) reading the data
+tic;
+cPos            = measOffset;
+twix_obj        = cell(1,NScans);
+
+for s=1:NScans
+    fseek(fid,cPos,'bof');
+    hdr_len = fread(fid, 1,'uint32');
+
+    % read header and calculate regridding (optional)
+    rstraj = [];
+    if arg.bReadHeader
+        [twix_obj{s}.hdr,rstraj] = read_twix_hdr(fid);
+    end
+
+    % declare data objects: DLP 7 Dec 2018: Changed this name (added _uk) because of
+    % changes to handle Siemens WIP MRTI sequence
+%     twix_obj{s}.image         = twix_map_obj_uk(arg,'image',filename,version,rstraj);
+%     twix_obj{s}.noise         = twix_map_obj_uk(arg,'noise',filename,version);
+%     twix_obj{s}.phasecor      = twix_map_obj_uk(arg,'phasecor',filename,version,rstraj);
+%     twix_obj{s}.phasestab     = twix_map_obj_uk(arg,'phasestab',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef0 = twix_map_obj_uk(arg,'phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef1 = twix_map_obj_uk(arg,'phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.refscan       = twix_map_obj_uk(arg,'refscan',filename,version,rstraj);
+%     twix_obj{s}.refscanPC     = twix_map_obj_uk(arg,'refscan_phasecor',filename,version,rstraj);
+%     twix_obj{s}.refscanPS     = twix_map_obj_uk(arg,'refscan_phasestab',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef0 = twix_map_obj_uk(arg,'refscan_phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef1 = twix_map_obj_uk(arg,'refscan_phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.RTfeedback    = twix_map_obj_uk(arg,'rtfeedback',filename,version,rstraj);
+%     twix_obj{s}.vop           = twix_map_obj_uk(arg,'vop',filename,version); % tx-array rf pulses
+    twix_obj{s}.image         = twix_map_obj_uk(arg,'image',filename,version);
+    twix_obj{s}.noise         = twix_map_obj_uk(arg,'noise',filename,version);
+    twix_obj{s}.phasecor      = twix_map_obj_uk(arg,'phasecor',filename,version);
+    twix_obj{s}.phasestab     = twix_map_obj_uk(arg,'phasestab',filename,version);
+    twix_obj{s}.phasestabRef0 = twix_map_obj_uk(arg,'phasestab_ref0',filename,version);
+    twix_obj{s}.phasestabRef1 = twix_map_obj_uk(arg,'phasestab_ref1',filename,version);
+    twix_obj{s}.refscan       = twix_map_obj_uk(arg,'refscan',filename,version);
+    twix_obj{s}.refscanPC     = twix_map_obj_uk(arg,'refscan_phasecor',filename,version);
+    twix_obj{s}.refscanPS     = twix_map_obj_uk(arg,'refscan_phasestab',filename,version);
+    twix_obj{s}.refscanPSRef0 = twix_map_obj_uk(arg,'refscan_phasestab_ref0',filename,version);
+    twix_obj{s}.refscanPSRef1 = twix_map_obj_uk(arg,'refscan_phasestab_ref1',filename,version);
+    twix_obj{s}.RTfeedback    = twix_map_obj_uk(arg,'rtfeedback',filename,version);
+    twix_obj{s}.vop           = twix_map_obj_uk(arg,'vop',filename,version); % tx-array rf pulses
+
+
+    % jump to first mdh
+    cPos = cPos + hdr_len;
+    fseek( fid, cPos, 'bof' );
+
+    % find all mdhs and save them in binary form, first:
+    fprintf('Scan %d/%d, read all mdhs:\n', s, NScans )
+
+    [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version );  % uint8; size: [ byteMDH  Nmeas ]
+
+    cPos = filePos( end );
+    filePos( end ) = [];
+
+    fprintf('          parse mdhs... ')
+    t0 = tic;
+
+    % get mdhs and masks for each scan, no matter if noise, image, RTfeedback etc:
+    [mdh, mask] = evalMDH( mdh_blob, version ); % this is quasi-instant (< 1s) :-)    
+    clear mdh_blob
+
+    % Assign mdhs to their respective scans and parse it in the correct twix objects.
+    %
+    if arg.bReadImaScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_IMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.image.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadNoiseScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_NOISEADJSCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.noise.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRefScan
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN )...
+                     & ~( mask.MDH_PHASCOR | mask.MDH_PHASESTABSCAN | ...
+                          mask.MDH_REFPHASESTABSCAN | ...
+                          mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK);
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscan.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRTfeedback
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK ) & ~mask.MDH_VOP;
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.RTfeedback.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK & mask.MDH_VOP );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.vop.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPCScan
+        % logic really correct?
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & ( ~mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasecor.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & (  mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPC.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPhaseStab
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestab.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPS.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    clear  mdh  tmpMdh  filePos  isCurrScan
+
+    for scan = { 'image', 'noise', 'phasecor', 'phasestab', ...
+                 'phasestabRef0', 'phasestabRef1', 'refscan', ...
+                 'refscanPC', 'refscanPS', 'refscanPSRef0', ...
+                 'refscanPSRef1', 'RTfeedback', 'vop' }
+        f = scan{1};
+
+        % remove unused fields
+        if twix_obj{s}.(f).NAcq == 0
+            twix_obj{s} = rmfield(twix_obj{s}, f );
+        else
+            if isEOF
+                % recover from read error
+                twix_obj{s}.(f).tryAndFixLastMdh();
+            else
+                twix_obj{s}.(f).clean();
+            end
+        end
+    end
+    fprintf('done. (%g seconds)\n', toc(t0) )
+
+end % NScans loop
+
+if NScans == 1
+    twix_obj = twix_obj{1};
+end
+
+end % of mapVBVD()
+
+
+
+
+function [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version )
+% Goal of this function is to gather all mdhs in the dat file and store them
+% in binary form, first. This enables us to evaluate and parse the stuff in
+% a MATLAB-friendly (vectorized) way. We also yield a clear separation between
+% a lengthy loop and other expressions that are evaluated very few times.
+%
+% The main challenge is that we never know a priori, where the next mdh is
+% and how many there are. So we have to actually evaluate some mdh fields to
+% find the next one.
+%
+% All slow things of the parsing step are found in the while loop.
+% => It is the (only) place where micro-optimizations are worthwhile.
+%
+% The current state is that we are close to sequential disk I/O times.
+% More fancy improvements may be possible by using workers through parfeval()
+% or threads using a java class (probably faster + no toolbox):
+% http://undocumentedmatlab.com/blog/explicit-multi-threading-in-matlab-part1
+
+    switch version
+        case 'vb'
+            isVD    = false;
+            byteMDH = 128;
+        case 'vd'
+            isVD    = true;
+            byteMDH = 184;
+            szScanHeader    = 192; % [bytes]
+            szChannelHeader =  32; % [bytes]
+        otherwise
+            % arbitrary assumptions:
+            isVD    = false;
+            byteMDH = 128;
+            warning( [mfilename() ':UnknownVer'], 'Software version "%s" is not supported.', version );
+    end
+
+    cPos            = ftell(fid);
+    n_acq           = 0;
+    allocSize       = 4096;
+    ulDMALength     = byteMDH;
+    isEOF           = false;
+    percentFinished = 0;
+    progress_str    = '';
+    prevLength      = numel( progress_str );
+
+    mdh_blob = zeros( byteMDH, 0, 'uint8' );
+    szBlob   = size( mdh_blob, 2 );
+    filePos  = zeros(0, 1, class(cPos));  % avoid bug in Matlab 2013b: https://scivision.co/matlab-fseek-bug-with-uint64-offset/
+
+    % get file size
+    fseek(fid,0,'eof');
+    fileSize = ftell(fid);
+    fseek(fid,cPos,'bof');
+
+    % ======================================
+    %   constants and conditional variables
+    % ======================================
+        bit_0 = uint8(2^0);
+        bit_5 = uint8(2^5);
+        mdhStart = 1-byteMDH;
+        
+        u8_000 = zeros( 3, 1, 'uint8'); % for comparison with data_u8(1:3)
+
+        % 20 fill bytes in VD (21:40)
+        evIdx   = uint8(    21  + 20*isVD); % 1st byte of evalInfoMask
+        dmaIdx  = uint8((29:32) + 20*isVD); % to correct DMA length using NCol and NCha
+        if isVD
+            dmaOff  = szScanHeader;
+            dmaSkip = szChannelHeader;
+        else
+            dmaOff  = 0;
+            dmaSkip = byteMDH;
+        end
+    % ======================================
+
+    t0 = tic;
+    while true
+        % Read mdh as binary (uint8) and evaluate as little as possible to know...
+        %   ... where the next mdh is (ulDMALength / ushSamplesInScan & ushUsedChannels)
+        %   ... whether it is only for sync (MDH_SYNCDATA)
+        %   ... whether it is the last one (MDH_ACQEND)
+        % evalMDH() contains the correct and readable code for all mdh entries.
+        try
+            % read everything and cut out the mdh
+            data_u8 = fread( fid, ulDMALength, 'uint8=>uint8' );
+            data_u8 = data_u8( mdhStart+end :  end );
+        catch exc
+            warning( [mfilename() ':UnxpctdEOF'],  ...
+                      [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                        'Will stop reading now.\n'                                             ...
+                        '=== MATLABs error message ================\n'                         ...
+                        exc.message                                                            ...
+                        '\n=== end of error =========================\n'                       ...
+                       ], cPos, cPos/1024^3 )
+            isEOF = true;
+            break
+        end
+
+        bitMask = data_u8(evIdx);   % the initial 8 bit from evalInfoMask are enough
+
+        if   isequal( data_u8(1:3), u8_000 )    ... % probably ulDMALength == 0
+          || bitand(bitMask, bit_0);                % MDH_ACQEND
+
+            % ok, look closer if really all *4* bytes are 0:
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+
+            if ulDMALength == 0 || bitand(bitMask, bit_0)
+                cPos = cPos + ulDMALength;
+                % jump to next full 512 bytes
+                if mod(cPos,512)
+                    cPos = cPos + 512 - mod(cPos,512);
+                end
+                break;
+            end
+        end
+        if bitand(bitMask, bit_5);  % MDH_SYNCDATA
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+            cPos = cPos + ulDMALength;
+            continue
+        end
+
+        % pehses: the pack bit indicates that multiple ADC are packed into one
+        % DMA, often in EPI scans (controlled by fRTSetReadoutPackaging in IDEA)
+        % since this code assumes one adc (x NCha) per DMA, we have to correct
+        % the "DMA length"
+        %     if mdh.ulPackBit
+        % it seems that the packbit is not always set correctly
+        NCol_NCha = double( typecast( data_u8(dmaIdx), 'uint16' ) );  % [ushSamplesInScan  ushUsedChannels]
+        ulDMALength = dmaOff + (8*NCol_NCha(1) + dmaSkip) * NCol_NCha(2);
+
+        n_acq = n_acq + 1;
+
+        % grow arrays in batches
+        if n_acq > szBlob
+            mdh_blob( :, end + allocSize ) = 0;
+            filePos( end + allocSize ) = 0;
+            szBlob = size( mdh_blob, 2 );
+        end
+        mdh_blob(:,n_acq) = data_u8;
+        filePos( n_acq )  = cPos;
+
+        if (100*cPos)/fileSize > percentFinished + 1
+            percentFinished = floor((100*cPos)/fileSize);
+            elapsed_time    = toc(t0);
+            time_left       = (fileSize/cPos-1) * elapsed_time;
+            prevLength      = numel(progress_str);
+            progress_str    = sprintf('    %3.0f %% read in %4.0f s; estimated time left: %4.0f s \n',...
+                                      percentFinished,elapsed_time, time_left);
+            fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+        end
+
+        cPos = cPos + ulDMALength;
+    end % while true
+
+    if isEOF
+        n_acq = n_acq-1;    % ignore the last attempt
+    end
+
+    filePos( n_acq+1 ) = cPos;  % save pointer to the next scan
+
+    % discard overallocation:
+    mdh_blob = mdh_blob(:,1:n_acq);
+    filePos  = reshape( filePos(1:n_acq+1), 1, [] ); % row vector
+
+    prevLength   = numel(progress_str) * (~isEOF);
+    elapsed_time = toc(t0);
+    progress_str = sprintf('    100 %% read in %4.0f s; estimated time left:    0 s \n', elapsed_time);
+    fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+
+end % of loop_mdh_read()
+
+
+
+function [mdh,mask] = evalMDH( mdh_blob, version )
+% see pkg/MrServers/MrMeasSrv/SeqIF/MDH/mdh.h
+% and pkg/MrServers/MrMeasSrv/SeqIF/MDH/MdhProxy.h
+
+if ~isa( mdh_blob, 'uint8' )
+    error( [mfilename() ':NoInt8'], 'Binary mdh data must be a uint8 array!' )
+end
+
+if version(end) == 'd'
+    isVD = true;
+    mdh_blob = mdh_blob([1:20 41:end], :);     % remove 20 unnecessary bytes
+else
+    isVD = false;
+end
+
+Nmeas   = size( mdh_blob, 2 );
+
+mdh.ulPackBit   = bitget( mdh_blob(4,:), 2).';
+mdh.ulPCI_rx    = bitset(bitset(mdh_blob(4,:), 7, 0), 8, 0).'; % keep 6 relevant bits
+mdh_blob(4,:)   = bitget( mdh_blob(4,:),1);  % ubit24: keep only 1 bit from the 4th byte
+
+% unfortunately, typecast works on vectors, only
+data_uint32     = typecast( reshape(mdh_blob(1:76,:),  [],1), 'uint32' );
+data_uint16     = typecast( reshape(mdh_blob(29:end,:),[],1), 'uint16' );
+data_single     = typecast( reshape(mdh_blob(69:end,:),[],1), 'single' );
+
+data_uint32 = reshape( data_uint32, [], Nmeas ).';
+data_uint16 = reshape( data_uint16, [], Nmeas ).';
+data_single = reshape( data_single, [], Nmeas ).';
+                                                        %  byte pos.
+%mdh.ulDMALength               = data_uint32(:,1);      %   1 :   4
+mdh.lMeasUID                   = data_uint32(:,2);      %   5 :   8
+mdh.ulScanCounter              = data_uint32(:,3);      %   9 :  12
+mdh.ulTimeStamp                = data_uint32(:,4);      %  13 :  16
+mdh.ulPMUTimeStamp             = data_uint32(:,5);      %  17 :  20
+mdh.aulEvalInfoMask            = data_uint32(:,6:7);    %  21 :  28
+mdh.ushSamplesInScan           = data_uint16(:,1);      %  29 :  30
+mdh.ushUsedChannels            = data_uint16(:,2);      %  31 :  32
+mdh.sLC                        = data_uint16(:,3:16);   %  33 :  60
+mdh.sCutOff                    = data_uint16(:,17:18);  %  61 :  64
+mdh.ushKSpaceCentreColumn      = data_uint16(:,19);     %  66 :  66
+mdh.ushCoilSelect              = data_uint16(:,20);     %  67 :  68
+mdh.fReadOutOffcentre          = data_single(:, 1);     %  69 :  72
+mdh.ulTimeSinceLastRF          = data_uint32(:,19);     %  73 :  76
+mdh.ushKSpaceCentreLineNo      = data_uint16(:,25);     %  77 :  78
+mdh.ushKSpaceCentrePartitionNo = data_uint16(:,26);     %  79 :  80
+
+if isVD
+    mdh.SlicePos                    = data_single(:, 4:10); %  81 : 108
+    mdh.aushIceProgramPara          = data_uint16(:,41:64); % 109 : 156
+    mdh.aushFreePara                = data_uint16(:,65:68); % 157 : 164
+else
+    mdh.aushIceProgramPara          = data_uint16(:,27:30); %  81 :  88
+    mdh.aushFreePara                = data_uint16(:,31:34); %  89 :  96
+    mdh.SlicePos                    = data_single(:, 8:14); %  97 : 124
+end
+
+% inlining of evalInfoMask
+evalInfoMask1 = mdh.aulEvalInfoMask(:,1);
+mask.MDH_ACQEND             = min(bitand(evalInfoMask1, 2^0), 1);
+mask.MDH_RTFEEDBACK         = min(bitand(evalInfoMask1, 2^1), 1);
+mask.MDH_HPFEEDBACK         = min(bitand(evalInfoMask1, 2^2), 1);
+mask.MDH_SYNCDATA           = min(bitand(evalInfoMask1, 2^5), 1);
+mask.MDH_RAWDATACORRECTION  = min(bitand(evalInfoMask1, 2^10),1);
+mask.MDH_REFPHASESTABSCAN   = min(bitand(evalInfoMask1, 2^14),1);
+mask.MDH_PHASESTABSCAN      = min(bitand(evalInfoMask1, 2^15),1);
+mask.MDH_SIGNREV            = min(bitand(evalInfoMask1, 2^17),1);
+mask.MDH_PHASCOR            = min(bitand(evalInfoMask1, 2^21),1);
+mask.MDH_PATREFSCAN         = min(bitand(evalInfoMask1, 2^22),1);
+mask.MDH_PATREFANDIMASCAN   = min(bitand(evalInfoMask1, 2^23),1);
+mask.MDH_REFLECT            = min(bitand(evalInfoMask1, 2^24),1);
+mask.MDH_NOISEADJSCAN       = min(bitand(evalInfoMask1, 2^25),1);
+mask.MDH_VOP                = min(bitand(mdh.aulEvalInfoMask(2), 2^(53-32)),1); % was 0 in VD
+
+mask.MDH_IMASCAN            = ones( Nmeas, 1, 'uint32' );
+
+noImaScan = (   mask.MDH_ACQEND             | mask.MDH_RTFEEDBACK   | mask.MDH_HPFEEDBACK       ...
+              | mask.MDH_PHASCOR            | mask.MDH_NOISEADJSCAN | mask.MDH_PHASESTABSCAN    ...
+              | mask.MDH_REFPHASESTABSCAN   | mask.MDH_SYNCDATA                                 ... 
+              | (mask.MDH_PATREFSCAN & ~mask.MDH_PATREFANDIMASCAN) );
+
+mask.MDH_IMASCAN( noImaScan ) = 0;
+
+end % of evalMDH()

--- a/matlab/read_kspace_dependencies/mapVBVD/mapVBVD_uk.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/mapVBVD_uk.m
@@ -1,0 +1,824 @@
+function twix_obj = mapVBVD_uk(filename,varargin)
+
+%  Reads Siemens raw .dat file from VB/VD MRI raw data.
+% 
+%  Requires twix_map_obj_uk.m
+% 
+%  Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de)
+% 
+% 
+%  Philipp Ehses 11.02.07, original version
+%  [..]
+%  Philipp Ehses 22.03.11, port to VD11
+%  Felix Breuer  31.03.11, added support for noise & ref scans, speed fixes
+%  Philipp Ehses 19.08.11, complete reorganization of code, added
+%                          siemens_data_obj class to improve readability
+%  Wolf Blecher  15.05.12, readout of slice position parameters for VB Data sets
+%  Wolf Blecher  11.06.12, added distinction between PATREF and PATREF PHASCOR
+%  Philipp Ehses 02.08.12, again massive code reorganization. The new class
+%                          twix_map_obj.m now stores the memory position of
+%                          each dataset (coils are included - size: NCol*NCha)
+%                          The actual data is not read until it is demanded
+%                          by a "data_obj()" call. This makes it possible
+%                          to selectively read in only parts of the data
+%                          (e.g. to preserve memory).
+%  Philipp Ehses 27.08.12, speed optimizations (avoiding of .-subsref calls)
+%  07.09.12 Thanks to Stephen Yutzy for implementing support for raw data
+%           correction (currently only supported for VB software version).
+%  15.01.13 Thanks to Zhitao Li for proper handling of SYNCDATA.
+%  Philipp Ehses 28.08.13, added support for VD13 multi-raid files
+%  Michael Völker May-Aug 15 * Better error tolerance with incomplete files.
+%                          * Swapped out parsing loop into a separate function
+%                            without access to twix object (no thousands of subsref calls).
+%                          * For parsing, use an as-minimalistic-as-possible loop
+%                            to gather all mdhs in binary form. They are all stored
+%                            in one array "mdh_blob".
+%                          * Translation of mdhs from binary to struct is vectorized 
+%                            and almost instant. It's done in evalMDH(), replacing
+%                            evalMDHvb() and evalMDHvd(), no more freads inside!
+%                          * vectorized readMDH(), quasi-instant
+%                          * When parsing, actually read the entire file without jumps.
+%                            This is weirdly faster than fseek(), plus the entire file is
+%                            kept in the file system cache, if possible. Next read
+%                            is therefore faster, too.
+%                          * => Parsing speed improved by factor 3...7 or so
+%                          * Speed increase for reading data, esp. when slicing,
+%                            os-removal or reflected lines. Also for random acquisitions.
+% 
+% 
+% Input:
+% 
+% filename or simply meas. id, e.g. mapVBVD(122) (if file is in same path)
+% optional arguments (see below)
+% 
+% Output: twix_obj structure with elements (if available):
+%     .image:         image scan
+%     .noise:         for noise scan
+%     .phasecor:      phase correction scan
+%     .phasestab:     phase stabilization scan
+%     .phasestabRef0: phase stab. ref. (MDH_REFPHASESTABSCAN && !MDH_PHASESTABSCAN)
+%     .phasestabRef1: phase stab. ref. (MDH_REFPHASESTABSCAN &&  MDH_PHASESTABSCAN)
+%     .refscan:       parallel imaging reference scan
+%     .refscanPC:     phase correction scan for reference data
+%     .refscanPS:     phase stabilization scan for reference data
+%     .refscanPSRef0: phase stab. ref scan for reference data
+%     .refscanPSRef1: phase stab. ref scan for reference data
+%     .RTfeedback:    realtime feedback data
+%     .vop:           vop rf data
+% 
+% 
+% The raw data can be obtained by calling e.g. twix_obj.image() or for
+% squeezed data twix_obj.image{''} (the '' are needed due to a limitation
+% of matlab's overloading capabilities).
+% Slicing is supported as well, e.g. twix_obj.image(:,:,1,:) will return
+% only the first line of the full data set (all later dimensions are
+% squeezed into one). Thus, slicing of the "memory-mapped" data objects
+% works exactly the same as regular matlab array slicing - with one
+% exception:
+% The keyword 'end' is not supported.
+% Overloading of the '()' and '{}' operators works by overloading matlab's
+% built-in 'subsref' function. Matlab calls subsref whenever the operators
+% '()', '{}', or '.' are called. In the latter case, the overloaded subsref
+% just calls the built-in subsref function since we don't want to change
+% the behaviour for '.'-calls. However, this has one minor consequence:
+% There's no way (afaik) to know whether the original call was terminated
+% with a semicolon. Thus, a call to e.g. twix_obj.image.NLin will produce
+% no output with or without semicolon termination. 'a = twix_obj.image.NLin'
+% will however produce the expected result.
+% 
+% 
+% Order of raw data:
+%  1) Columns
+%  2) Channels/Coils
+%  3) Lines
+%  4) Partitions
+%  5) Slices
+%  6) Averages
+%  7) (Cardiac-) Phases
+%  8) Contrasts/Echoes
+%  9) Measurements
+% 10) Sets
+% 11) Segments
+% 12) Ida
+% 13) Idb
+% 14) Idc
+% 15) Idd
+% 16) Ide
+% 
+% 
+% Optional parameters/flags:
+% 
+% removeOS:          removes oversampling (factor 2) in read direction
+% doAverage:         performs average (resulting avg-dim has thus size 1)
+% ignoreSeg:         ignores segment mdh index (works basically the same as
+%                    the average flag)
+% rampSampRegrid     optional on-the-fly regridding of ramp-sampled readout
+% doRawDataCorrect:  enables raw data correction if used in the acquisition
+%                    (only works for VB atm)
+% 
+% These flags can also be set/unset later, e.g "twix_obj.image.flagRemoveOS = 1"
+% 
+% 
+% Examples:
+%   twix_obj = mapVBVD(measID);
+% 
+%   % return all image-data:
+%   image_data = twix_obj.image();
+%   % return all image-data with all singular dimensions removed/squeezed:
+%   image_data = twix_obj.image{''}; % '' necessary due to a matlab limitation
+%   % return only data for line numbers 1 and 5; all dims higher than 4 are
+%   % grouped into dim 5):
+%   image_data = twix_obj.image(:,:,[1 5],:,:);
+%   % return only data for coil channels 2 to 6; all dims higher than 4 are
+%   % grouped into dim 5); but work with the squeezed data order
+%   % => use '{}' instead of '()':
+%   image_data = twix_obj.image{:,2:6,:,:,:};
+% 
+%   So basically it works like regular matlab array slicing (but 'end' is
+%   not supported; note that there are still a few bugs with array slicing).
+% 
+%   % NEW: unsorted raw data (in acq. order):
+%   image_data = twix_obj.image.unsorted(); % no slicing supported atm
+% 
+% 
+% Suppress silly editor warnings in the entire file, barking about
+% unused variables:
+%#ok<*NASGU>
+
+if ~exist('filename','var') || isempty(filename)
+    info = 'Please select binary file to read';
+    [fname,pathname]=uigetfile('*.dat',info);
+    if isempty(pathname)
+        return
+    end
+    filename=[pathname fname];
+else
+    if ischar(filename)
+        % assume that complete path is given
+        if  ~strcmpi(filename(end-3:end),'.dat');
+            filename=[filename '.dat'];   %% adds filetype ending to file
+        end
+    else
+        % filename not a string, so assume that it is the MeasID
+        measID   = filename;
+        filelist = dir('*.dat');
+        filesfound = 0;
+        for k=1:numel(filelist)
+            if regexp(filelist(k).name,['^meas_MID0*' num2str(measID) '_.*\.dat'])==1
+                if filesfound == 0
+                    filename = filelist(k).name;
+                end
+                filesfound = filesfound+1;
+            end
+        end
+        if filesfound == 0
+            error(['File with meas. id ' num2str(measID) ' not found.']);
+        elseif filesfound > 1
+            disp(['Multiple files with meas. id ' num2str(measID) ' found. Choosing first occurence.']);
+        end
+    end
+end
+
+% add absolute path, when no path is given
+[pathstr, name, ext] = fileparts(filename);
+
+if isempty(pathstr)
+    pathstr  = pwd;
+    filename = fullfile(pathstr, [name ext]);
+end
+
+%%%%% Parse varargin %%%%%
+arg.bReadImaScan    = true;
+arg.bReadNoiseScan  = true;
+arg.bReadPCScan     = true;
+arg.bReadRefScan    = true;
+arg.bReadRefPCScan  = true;
+arg.bReadRTfeedback = true;
+arg.bReadPhaseStab  = true;
+arg.bReadHeader     = true;
+
+k=1;
+while k <= numel(varargin)
+
+    if ~ischar(varargin{k})
+        error('string expected');
+    end
+
+    switch lower(varargin{k})
+        case {'readheader','readhdr','header','hdr'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.bReadHeader = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.bReadHeader = true;
+                k = k+1;
+            end
+        case {'removeos','rmos'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.removeOS = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.removeOS = true;
+                k = k+1;
+            end
+        case {'doaverage','doave','ave','average'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doAverage = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doAverage = true;
+                k = k+1;
+            end
+        case {'averagereps','averagerepetitions'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageReps = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageReps = true;
+                k = k+1;
+            end
+        case {'averagesets'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageSets = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageSets = true;
+                k = k+1;
+            end
+        case {'ignseg','ignsegments','ignoreseg','ignoresegments'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.ignoreSeg = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.ignoreSeg = true;
+                k = k+1;
+            end
+        case {'rampsampregrid','regrid'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.rampSampRegrid = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.rampSampRegrid = true;
+                k = k+1;
+            end
+        case {'rawdatacorrect','dorawdatacorrect'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doRawDataCorrect = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doRawDataCorrect = true;
+                k = k+1;
+            end
+        otherwise
+            error('Argument not recognized.');
+    end
+end
+clear varargin
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+tic;
+fid = fopen(filename,'r','l','US-ASCII');
+
+% start of actual measurement data (sans header)
+fseek(fid,0,'bof');
+
+firstInt  = fread(fid,1,'uint32');
+secondInt = fread(fid,1,'uint32');
+
+% lazy software version check (VB or VD?)
+if and(firstInt < 10000, secondInt <= 64)
+    version = 'vd';
+    disp('Software version: VD (!?)');
+
+    % number of different scans in file stored in 2nd in
+    NScans = secondInt;
+    measID = fread(fid,1,'uint32');
+    fileID = fread(fid,1,'uint32');
+    % measOffset: points to beginning of header, usually at 10240 bytes
+    measOffset = fread(fid,1,'uint64');
+    measLength = fread(fid,1,'uint64');
+    fseek(fid,measOffset,'bof');
+    hdrLength  = fread(fid,1,'uint32');
+
+else
+    % in VB versions, the first 4 bytes indicate the beginning of the
+    % raw data part of the file
+    version  = 'vb';
+    disp('Software version: VB (!?)');
+    measOffset = 0;
+    hdrLength  = firstInt;
+    NScans     = 1; % VB does not support multiple scans in one file
+end
+datStart = measOffset + hdrLength;
+
+%SRY read data correction factors
+% do this for all VB datasets, so that the factors are available later
+% in the image_obj if the user chooses to set the correction flag
+if (strcmp(version, 'vb')) % not implemented/tested for vd, yet
+    frewind(fid);
+    while ( (ftell(fid) < datStart) && ~exist('rawfactors', 'var'))
+        line = fgetl(fid);
+        %find the section of the protocol
+        %note: the factors are also available in <ParamArray."CoilSelects">
+        %along with element name and FFT scale, but the parsing is
+        %significantly more difficult
+        if (~isempty(strfind(line, '<ParamArray."axRawDataCorrectionFactor">')))
+            while (ftell(fid) < datStart)
+                line = fgetl(fid);
+                %find the line with correction factors
+                %the factors are on the first line that begins with this
+                %pattern
+                if (~isempty(strfind(line, '{ {  { ')))
+                    line = strrep(line, '}  { } ', '0.0');
+                    line = strrep(line, '{', '');
+                    line = strrep(line, '}', '');
+                    rawfactors = textscan(line, '%f');
+                    rawfactors = rawfactors{1}; %textscan returns a 1x1 cell array
+                    % this does not work in this location because the MDHs
+                    % have not been parsed yet
+                    %                    if (length(rawfactors) ~= 2*max(image_obj.NCha))
+                    %                       error('Number of raw factors (%f) does not equal channel count (%d)', length(rawfactors)/2, image_obj.NCha);
+                    %                    end;
+                    if (mod(length(rawfactors),2) ~= 0)
+                        error('Error reading rawfactors');
+                    end;
+                    %note the transpose, this makes the vector
+                    %multiplication during the read easier
+                    arg.rawDataCorrectionFactors = rawfactors(1:2:end).' + 1i*rawfactors(2:2:end).';
+                    break;
+                end
+            end
+        end
+    end
+    disp('Read raw data correction factors');
+end
+
+% data will be read in two steps (two while loops):
+%   1) reading all MDHs to find maximum line no., partition no.,... for
+%      ima, ref,... scan
+%   2) reading the data
+tic;
+cPos            = measOffset;
+twix_obj        = cell(1,NScans);
+
+for s=1:NScans
+    fseek(fid,cPos,'bof');
+    hdr_len = fread(fid, 1,'uint32');
+
+    % read header and calculate regridding (optional)
+    rstraj = [];
+    if arg.bReadHeader
+        [twix_obj{s}.hdr,rstraj] = read_twix_hdr(fid);
+    end
+
+    % declare data objects: DLP 7 Dec 2018: Changed this name (added _uk) because of
+    % changes to handle Siemens WIP MRTI sequence
+%     twix_obj{s}.image         = twix_map_obj_uk(arg,'image',filename,version,rstraj);
+%     twix_obj{s}.noise         = twix_map_obj_uk(arg,'noise',filename,version);
+%     twix_obj{s}.phasecor      = twix_map_obj_uk(arg,'phasecor',filename,version,rstraj);
+%     twix_obj{s}.phasestab     = twix_map_obj_uk(arg,'phasestab',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef0 = twix_map_obj_uk(arg,'phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef1 = twix_map_obj_uk(arg,'phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.refscan       = twix_map_obj_uk(arg,'refscan',filename,version,rstraj);
+%     twix_obj{s}.refscanPC     = twix_map_obj_uk(arg,'refscan_phasecor',filename,version,rstraj);
+%     twix_obj{s}.refscanPS     = twix_map_obj_uk(arg,'refscan_phasestab',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef0 = twix_map_obj_uk(arg,'refscan_phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef1 = twix_map_obj_uk(arg,'refscan_phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.RTfeedback    = twix_map_obj_uk(arg,'rtfeedback',filename,version,rstraj);
+%     twix_obj{s}.vop           = twix_map_obj_uk(arg,'vop',filename,version); % tx-array rf pulses
+    twix_obj{s}.image         = twix_map_obj_ukHO(arg,'image',filename,version);
+    twix_obj{s}.noise         = twix_map_obj_uk(arg,'noise',filename,version);
+    twix_obj{s}.phasecor      = twix_map_obj_uk(arg,'phasecor',filename,version);
+    twix_obj{s}.phasestab     = twix_map_obj_uk(arg,'phasestab',filename,version);
+    twix_obj{s}.phasestabRef0 = twix_map_obj_uk(arg,'phasestab_ref0',filename,version);
+    twix_obj{s}.phasestabRef1 = twix_map_obj_uk(arg,'phasestab_ref1',filename,version);
+    twix_obj{s}.refscan       = twix_map_obj_uk(arg,'refscan',filename,version);
+    twix_obj{s}.refscanPC     = twix_map_obj_uk(arg,'refscan_phasecor',filename,version);
+    twix_obj{s}.refscanPS     = twix_map_obj_uk(arg,'refscan_phasestab',filename,version);
+    twix_obj{s}.refscanPSRef0 = twix_map_obj_uk(arg,'refscan_phasestab_ref0',filename,version);
+    twix_obj{s}.refscanPSRef1 = twix_map_obj_uk(arg,'refscan_phasestab_ref1',filename,version);
+    twix_obj{s}.RTfeedback    = twix_map_obj_uk(arg,'rtfeedback',filename,version);
+    twix_obj{s}.vop           = twix_map_obj_uk(arg,'vop',filename,version); % tx-array rf pulses
+
+
+    % jump to first mdh
+    cPos = cPos + hdr_len;
+    fseek( fid, cPos, 'bof' );
+
+    % find all mdhs and save them in binary form, first:
+    fprintf('Scan %d/%d, read all mdhs:\n', s, NScans )
+
+    [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version );  % uint8; size: [ byteMDH  Nmeas ]
+
+    cPos = filePos( end );
+    filePos( end ) = [];
+
+    fprintf('          parse mdhs... ')
+    t0 = tic;
+
+    % get mdhs and masks for each scan, no matter if noise, image, RTfeedback etc:
+    [mdh, mask] = evalMDH( mdh_blob, version ); % this is quasi-instant (< 1s) :-)    
+    clear mdh_blob
+
+    % Assign mdhs to their respective scans and parse it in the correct twix objects.
+    %
+    if arg.bReadImaScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_IMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.image.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadNoiseScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_NOISEADJSCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.noise.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRefScan
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN )...
+                     & ~( mask.MDH_PHASCOR | mask.MDH_PHASESTABSCAN | ...
+                          mask.MDH_REFPHASESTABSCAN | ...
+                          mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK);
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscan.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRTfeedback
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK ) & ~mask.MDH_VOP;
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.RTfeedback.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK & mask.MDH_VOP );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.vop.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPCScan
+        % logic really correct?
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & ( ~mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasecor.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & (  mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPC.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPhaseStab
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestab.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPS.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    twix_obj{s}.hdr.ulTimeStamp = mdh.ulTimeStamp; % DEP 01/07/19
+    [twix_obj{s}.hdr.ulAcquisitionTimeStamp, twix_obj{s}.hdr.ulAcquisitionStrTimeStamp] = AcqTime(twix_obj{s}.hdr, 1); % DEP 01/08/09
+    clear  mdh  tmpMdh  filePos  isCurrScan
+
+    for scan = { 'image', 'noise', 'phasecor', 'phasestab', ...
+                 'phasestabRef0', 'phasestabRef1', 'refscan', ...
+                 'refscanPC', 'refscanPS', 'refscanPSRef0', ...
+                 'refscanPSRef1', 'RTfeedback', 'vop' }
+        f = scan{1};
+
+        % remove unused fields
+        if twix_obj{s}.(f).NAcq == 0
+            twix_obj{s} = rmfield(twix_obj{s}, f );
+        else
+            if isEOF
+                % recover from read error
+                twix_obj{s}.(f).tryAndFixLastMdh();
+            else
+                twix_obj{s}.(f).clean();
+            end
+        end
+    end
+    fprintf('done. (%g seconds)\n', toc(t0) )
+
+end % NScans loop
+
+if NScans == 1
+    twix_obj = twix_obj{1};
+end
+
+end % of mapVBVD()
+
+
+
+
+function [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version )
+% Goal of this function is to gather all mdhs in the dat file and store them
+% in binary form, first. This enables us to evaluate and parse the stuff in
+% a MATLAB-friendly (vectorized) way. We also yield a clear separation between
+% a lengthy loop and other expressions that are evaluated very few times.
+%
+% The main challenge is that we never know a priori, where the next mdh is
+% and how many there are. So we have to actually evaluate some mdh fields to
+% find the next one.
+%
+% All slow things of the parsing step are found in the while loop.
+% => It is the (only) place where micro-optimizations are worthwhile.
+%
+% The current state is that we are close to sequential disk I/O times.
+% More fancy improvements may be possible by using workers through parfeval()
+% or threads using a java class (probably faster + no toolbox):
+% http://undocumentedmatlab.com/blog/explicit-multi-threading-in-matlab-part1
+
+    switch version
+        case 'vb'
+            isVD    = false;
+            byteMDH = 128;
+        case 'vd'
+            isVD    = true;
+            byteMDH = 184;
+            szScanHeader    = 192; % [bytes]
+            szChannelHeader =  32; % [bytes]
+        otherwise
+            % arbitrary assumptions:
+            isVD    = false;
+            byteMDH = 128;
+            warning( [mfilename() ':UnknownVer'], 'Software version "%s" is not supported.', version );
+    end
+
+    cPos            = ftell(fid);
+    n_acq           = 0;
+    allocSize       = 4096;
+    ulDMALength     = byteMDH;
+    isEOF           = false;
+    percentFinished = 0;
+    progress_str    = '';
+    prevLength      = numel( progress_str );
+
+    mdh_blob = zeros( byteMDH, 0, 'uint8' );
+    szBlob   = size( mdh_blob, 2 );
+    filePos  = zeros(0, 1, class(cPos));  % avoid bug in Matlab 2013b: https://scivision.co/matlab-fseek-bug-with-uint64-offset/
+
+    % get file size
+    fseek(fid,0,'eof');
+    fileSize = ftell(fid);
+    fseek(fid,cPos,'bof');
+
+    % ======================================
+    %   constants and conditional variables
+    % ======================================
+        bit_0 = uint8(2^0);
+        bit_5 = uint8(2^5);
+        mdhStart = 1-byteMDH;
+        
+        u8_000 = zeros( 3, 1, 'uint8'); % for comparison with data_u8(1:3)
+
+        % 20 fill bytes in VD (21:40)
+        evIdx   = uint8(    21  + 20*isVD); % 1st byte of evalInfoMask
+        dmaIdx  = uint8((29:32) + 20*isVD); % to correct DMA length using NCol and NCha
+        if isVD
+            dmaOff  = szScanHeader;
+            dmaSkip = szChannelHeader;
+        else
+            dmaOff  = 0;
+            dmaSkip = byteMDH;
+        end
+    % ======================================
+
+    t0 = tic;
+    while true
+        % Read mdh as binary (uint8) and evaluate as little as possible to know...
+        %   ... where the next mdh is (ulDMALength / ushSamplesInScan & ushUsedChannels)
+        %   ... whether it is only for sync (MDH_SYNCDATA)
+        %   ... whether it is the last one (MDH_ACQEND)
+        % evalMDH() contains the correct and readable code for all mdh entries.
+        try
+            % read everything and cut out the mdh
+            data_u8 = fread( fid, ulDMALength, 'uint8=>uint8' );
+            data_u8 = data_u8( mdhStart+end :  end );
+        catch exc
+            warning( [mfilename() ':UnxpctdEOF'],  ...
+                      [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                        'Will stop reading now.\n'                                             ...
+                        '=== MATLABs error message ================\n'                         ...
+                        exc.message                                                            ...
+                        '\n=== end of error =========================\n'                       ...
+                       ], cPos, cPos/1024^3 )
+            isEOF = true;
+            break
+        end
+
+        bitMask = data_u8(evIdx);   % the initial 8 bit from evalInfoMask are enough
+
+        if   isequal( data_u8(1:3), u8_000 )    ... % probably ulDMALength == 0
+          || bitand(bitMask, bit_0);                % MDH_ACQEND
+
+            % ok, look closer if really all *4* bytes are 0:
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+
+            if ulDMALength == 0 || bitand(bitMask, bit_0)
+                cPos = cPos + ulDMALength;
+                % jump to next full 512 bytes
+                if mod(cPos,512)
+                    cPos = cPos + 512 - mod(cPos,512);
+                end
+                break;
+            end
+        end
+        if bitand(bitMask, bit_5);  % MDH_SYNCDATA
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+            cPos = cPos + ulDMALength;
+            continue
+        end
+
+        % pehses: the pack bit indicates that multiple ADC are packed into one
+        % DMA, often in EPI scans (controlled by fRTSetReadoutPackaging in IDEA)
+        % since this code assumes one adc (x NCha) per DMA, we have to correct
+        % the "DMA length"
+        %     if mdh.ulPackBit
+        % it seems that the packbit is not always set correctly
+        NCol_NCha = double( typecast( data_u8(dmaIdx), 'uint16' ) );  % [ushSamplesInScan  ushUsedChannels]
+        ulDMALength = dmaOff + (8*NCol_NCha(1) + dmaSkip) * NCol_NCha(2);
+
+        n_acq = n_acq + 1;
+
+        % grow arrays in batches
+        if n_acq > szBlob
+            mdh_blob( :, end + allocSize ) = 0;
+            filePos( end + allocSize ) = 0;
+            szBlob = size( mdh_blob, 2 );
+        end
+        mdh_blob(:,n_acq) = data_u8;
+        filePos( n_acq )  = cPos;
+
+        if (100*cPos)/fileSize > percentFinished + 1
+            percentFinished = floor((100*cPos)/fileSize);
+            elapsed_time    = toc(t0);
+            time_left       = (fileSize/cPos-1) * elapsed_time;
+            prevLength      = numel(progress_str);
+            progress_str    = sprintf('    %3.0f %% read in %4.0f s; estimated time left: %4.0f s \n',...
+                                      percentFinished,elapsed_time, time_left);
+            fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+        end
+
+        cPos = cPos + ulDMALength;
+    end % while true
+
+    if isEOF
+        n_acq = n_acq-1;    % ignore the last attempt
+    end
+
+    filePos( n_acq+1 ) = cPos;  % save pointer to the next scan
+
+    % discard overallocation:
+    mdh_blob = mdh_blob(:,1:n_acq);
+    filePos  = reshape( filePos(1:n_acq+1), 1, [] ); % row vector
+
+    prevLength   = numel(progress_str) * (~isEOF);
+    elapsed_time = toc(t0);
+    progress_str = sprintf('    100 %% read in %4.0f s; estimated time left:    0 s \n', elapsed_time);
+    fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+
+end % of loop_mdh_read()
+
+
+
+function [mdh,mask] = evalMDH( mdh_blob, version )
+% see pkg/MrServers/MrMeasSrv/SeqIF/MDH/mdh.h
+% and pkg/MrServers/MrMeasSrv/SeqIF/MDH/MdhProxy.h
+
+if ~isa( mdh_blob, 'uint8' )
+    error( [mfilename() ':NoInt8'], 'Binary mdh data must be a uint8 array!' )
+end
+
+if version(end) == 'd'
+    isVD = true;
+    mdh_blob = mdh_blob([1:20 41:end], :);     % remove 20 unnecessary bytes
+else
+    isVD = false;
+end
+
+Nmeas   = size( mdh_blob, 2 );
+
+mdh.ulPackBit   = bitget( mdh_blob(4,:), 2).';
+mdh.ulPCI_rx    = bitset(bitset(mdh_blob(4,:), 7, 0), 8, 0).'; % keep 6 relevant bits
+mdh_blob(4,:)   = bitget( mdh_blob(4,:),1);  % ubit24: keep only 1 bit from the 4th byte
+
+% unfortunately, typecast works on vectors, only
+data_uint32     = typecast( reshape(mdh_blob(1:76,:),  [],1), 'uint32' );
+data_uint16     = typecast( reshape(mdh_blob(29:end,:),[],1), 'uint16' );
+data_single     = typecast( reshape(mdh_blob(69:end,:),[],1), 'single' );
+
+data_uint32 = reshape( data_uint32, [], Nmeas ).';
+data_uint16 = reshape( data_uint16, [], Nmeas ).';
+data_single = reshape( data_single, [], Nmeas ).';
+                                                        %  byte pos.
+%mdh.ulDMALength               = data_uint32(:,1);      %   1 :   4
+mdh.lMeasUID                   = data_uint32(:,2);      %   5 :   8
+mdh.ulScanCounter              = data_uint32(:,3);      %   9 :  12
+mdh.ulTimeStamp                = data_uint32(:,4);      %  13 :  16
+mdh.ulPMUTimeStamp             = data_uint32(:,5);      %  17 :  20
+mdh.aulEvalInfoMask            = data_uint32(:,6:7);    %  21 :  28
+mdh.ushSamplesInScan           = data_uint16(:,1);      %  29 :  30
+mdh.ushUsedChannels            = data_uint16(:,2);      %  31 :  32
+mdh.sLC                        = data_uint16(:,3:16);   %  33 :  60
+mdh.sCutOff                    = data_uint16(:,17:18);  %  61 :  64
+mdh.ushKSpaceCentreColumn      = data_uint16(:,19);     %  66 :  66
+mdh.ushCoilSelect              = data_uint16(:,20);     %  67 :  68
+mdh.fReadOutOffcentre          = data_single(:, 1);     %  69 :  72
+mdh.ulTimeSinceLastRF          = data_uint32(:,19);     %  73 :  76
+mdh.ushKSpaceCentreLineNo      = data_uint16(:,25);     %  77 :  78
+mdh.ushKSpaceCentrePartitionNo = data_uint16(:,26);     %  79 :  80
+
+if isVD
+    mdh.SlicePos                    = data_single(:, 4:10); %  81 : 108
+    mdh.aushIceProgramPara          = data_uint16(:,41:64); % 109 : 156
+    mdh.aushFreePara                = data_uint16(:,65:68); % 157 : 164
+else
+    mdh.aushIceProgramPara          = data_uint16(:,27:30); %  81 :  88
+    mdh.aushFreePara                = data_uint16(:,31:34); %  89 :  96
+    mdh.SlicePos                    = data_single(:, 8:14); %  97 : 124
+end
+
+% inlining of evalInfoMask
+evalInfoMask1 = mdh.aulEvalInfoMask(:,1);
+mask.MDH_ACQEND             = min(bitand(evalInfoMask1, 2^0), 1);
+mask.MDH_RTFEEDBACK         = min(bitand(evalInfoMask1, 2^1), 1);
+mask.MDH_HPFEEDBACK         = min(bitand(evalInfoMask1, 2^2), 1);
+mask.MDH_SYNCDATA           = min(bitand(evalInfoMask1, 2^5), 1);
+mask.MDH_RAWDATACORRECTION  = min(bitand(evalInfoMask1, 2^10),1);
+mask.MDH_REFPHASESTABSCAN   = min(bitand(evalInfoMask1, 2^14),1);
+mask.MDH_PHASESTABSCAN      = min(bitand(evalInfoMask1, 2^15),1);
+mask.MDH_SIGNREV            = min(bitand(evalInfoMask1, 2^17),1);
+mask.MDH_PHASCOR            = min(bitand(evalInfoMask1, 2^21),1);
+mask.MDH_PATREFSCAN         = min(bitand(evalInfoMask1, 2^22),1);
+mask.MDH_PATREFANDIMASCAN   = min(bitand(evalInfoMask1, 2^23),1);
+mask.MDH_REFLECT            = min(bitand(evalInfoMask1, 2^24),1);
+mask.MDH_NOISEADJSCAN       = min(bitand(evalInfoMask1, 2^25),1);
+mask.MDH_VOP                = min(bitand(mdh.aulEvalInfoMask(2), 2^(53-32)),1); % was 0 in VD
+
+mask.MDH_IMASCAN            = ones( Nmeas, 1, 'uint32' );
+
+noImaScan = (   mask.MDH_ACQEND             | mask.MDH_RTFEEDBACK   | mask.MDH_HPFEEDBACK       ...
+              | mask.MDH_PHASCOR            | mask.MDH_NOISEADJSCAN | mask.MDH_PHASESTABSCAN    ...
+              | mask.MDH_REFPHASESTABSCAN   | mask.MDH_SYNCDATA                                 ... 
+              | (mask.MDH_PATREFSCAN & ~mask.MDH_PATREFANDIMASCAN) );
+
+mask.MDH_IMASCAN( noImaScan ) = 0;
+
+end % of evalMDH()

--- a/matlab/read_kspace_dependencies/mapVBVD/mapVBVD_ukHO.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/mapVBVD_ukHO.m
@@ -1,0 +1,825 @@
+function twix_obj = mapVBVD_uk(filename,varargin)
+
+%  Reads Siemens raw .dat file from VB/VD MRI raw data.
+% 
+%  Requires twix_map_obj_ukHO.m
+% 
+%  Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de)
+% 
+% 
+%  Philipp Ehses 11.02.07, original version
+%  [..]
+%  Philipp Ehses 22.03.11, port to VD11
+%  Felix Breuer  31.03.11, added support for noise & ref scans, speed fixes
+%  Philipp Ehses 19.08.11, complete reorganization of code, added
+%                          siemens_data_obj class to improve readability
+%  Wolf Blecher  15.05.12, readout of slice position parameters for VB Data sets
+%  Wolf Blecher  11.06.12, added distinction between PATREF and PATREF PHASCOR
+%  Philipp Ehses 02.08.12, again massive code reorganization. The new class
+%                          twix_map_obj.m now stores the memory position of
+%                          each dataset (coils are included - size: NCol*NCha)
+%                          The actual data is not read until it is demanded
+%                          by a "data_obj()" call. This makes it possible
+%                          to selectively read in only parts of the data
+%                          (e.g. to preserve memory).
+%  Philipp Ehses 27.08.12, speed optimizations (avoiding of .-subsref calls)
+%  07.09.12 Thanks to Stephen Yutzy for implementing support for raw data
+%           correction (currently only supported for VB software version).
+%  15.01.13 Thanks to Zhitao Li for proper handling of SYNCDATA.
+%  Philipp Ehses 28.08.13, added support for VD13 multi-raid files
+%  Michael Völker May-Aug 15 * Better error tolerance with incomplete files.
+%                          * Swapped out parsing loop into a separate function
+%                            without access to twix object (no thousands of subsref calls).
+%                          * For parsing, use an as-minimalistic-as-possible loop
+%                            to gather all mdhs in binary form. They are all stored
+%                            in one array "mdh_blob".
+%                          * Translation of mdhs from binary to struct is vectorized 
+%                            and almost instant. It's done in evalMDH(), replacing
+%                            evalMDHvb() and evalMDHvd(), no more freads inside!
+%                          * vectorized readMDH(), quasi-instant
+%                          * When parsing, actually read the entire file without jumps.
+%                            This is weirdly faster than fseek(), plus the entire file is
+%                            kept in the file system cache, if possible. Next read
+%                            is therefore faster, too.
+%                          * => Parsing speed improved by factor 3...7 or so
+%                          * Speed increase for reading data, esp. when slicing,
+%                            os-removal or reflected lines. Also for random acquisitions.
+% 
+% 
+% Input:
+% 
+% filename or simply meas. id, e.g. mapVBVD(122) (if file is in same path)
+% optional arguments (see below)
+% 
+% Output: twix_obj structure with elements (if available):
+%     .image:         image scan
+%     .noise:         for noise scan
+%     .phasecor:      phase correction scan
+%     .phasestab:     phase stabilization scan
+%     .phasestabRef0: phase stab. ref. (MDH_REFPHASESTABSCAN && !MDH_PHASESTABSCAN)
+%     .phasestabRef1: phase stab. ref. (MDH_REFPHASESTABSCAN &&  MDH_PHASESTABSCAN)
+%     .refscan:       parallel imaging reference scan
+%     .refscanPC:     phase correction scan for reference data
+%     .refscanPS:     phase stabilization scan for reference data
+%     .refscanPSRef0: phase stab. ref scan for reference data
+%     .refscanPSRef1: phase stab. ref scan for reference data
+%     .RTfeedback:    realtime feedback data
+%     .vop:           vop rf data
+% 
+% 
+% The raw data can be obtained by calling e.g. twix_obj.image() or for
+% squeezed data twix_obj.image{''} (the '' are needed due to a limitation
+% of matlab's overloading capabilities).
+% Slicing is supported as well, e.g. twix_obj.image(:,:,1,:) will return
+% only the first line of the full data set (all later dimensions are
+% squeezed into one). Thus, slicing of the "memory-mapped" data objects
+% works exactly the same as regular matlab array slicing - with one
+% exception:
+% The keyword 'end' is not supported.
+% Overloading of the '()' and '{}' operators works by overloading matlab's
+% built-in 'subsref' function. Matlab calls subsref whenever the operators
+% '()', '{}', or '.' are called. In the latter case, the overloaded subsref
+% just calls the built-in subsref function since we don't want to change
+% the behaviour for '.'-calls. However, this has one minor consequence:
+% There's no way (afaik) to know whether the original call was terminated
+% with a semicolon. Thus, a call to e.g. twix_obj.image.NLin will produce
+% no output with or without semicolon termination. 'a = twix_obj.image.NLin'
+% will however produce the expected result.
+% 
+% 
+% Order of raw data:
+%  1) Columns
+%  2) Channels/Coils
+%  3) Lines
+%  4) Partitions
+%  5) Slices
+%  6) Averages
+%  7) (Cardiac-) Phases
+%  8) Contrasts/Echoes
+%  9) Measurements
+% 10) Sets
+% 11) Segments
+% 12) Ida
+% 13) Idb
+% 14) Idc
+% 15) Idd
+% 16) Ide
+% 
+% 
+% Optional parameters/flags:
+% 
+% removeOS:          removes oversampling (factor 2) in read direction
+% doAverage:         performs average (resulting avg-dim has thus size 1)
+% ignoreSeg:         ignores segment mdh index (works basically the same as
+%                    the average flag)
+% rampSampRegrid     optional on-the-fly regridding of ramp-sampled readout
+% doRawDataCorrect:  enables raw data correction if used in the acquisition
+%                    (only works for VB atm)
+% 
+% These flags can also be set/unset later, e.g "twix_obj.image.flagRemoveOS = 1"
+% 
+% 
+% Examples:
+%   twix_obj = mapVBVD(measID);
+% 
+%   % return all image-data:
+%   image_data = twix_obj.image();
+%   % return all image-data with all singular dimensions removed/squeezed:
+%   image_data = twix_obj.image{''}; % '' necessary due to a matlab limitation
+%   % return only data for line numbers 1 and 5; all dims higher than 4 are
+%   % grouped into dim 5):
+%   image_data = twix_obj.image(:,:,[1 5],:,:);
+%   % return only data for coil channels 2 to 6; all dims higher than 4 are
+%   % grouped into dim 5); but work with the squeezed data order
+%   % => use '{}' instead of '()':
+%   image_data = twix_obj.image{:,2:6,:,:,:};
+% 
+%   So basically it works like regular matlab array slicing (but 'end' is
+%   not supported; note that there are still a few bugs with array slicing).
+% 
+%   % NEW: unsorted raw data (in acq. order):
+%   image_data = twix_obj.image.unsorted(); % no slicing supported atm
+% 
+% 
+% Suppress silly editor warnings in the entire file, barking about
+% unused variables:
+%#ok<*NASGU>
+
+if ~exist('filename','var') || isempty(filename)
+    info = 'Please select binary file to read';
+    [fname,pathname]=uigetfile('*.dat',info);
+    if isempty(pathname)
+        return
+    end
+    filename=[pathname fname];
+else
+    if ischar(filename)
+        % assume that complete path is given
+        if  ~strcmpi(filename(end-3:end),'.dat');
+            filename=[filename '.dat'];   %% adds filetype ending to file
+        end
+    else
+        % filename not a string, so assume that it is the MeasID
+        measID   = filename;
+        filelist = dir('*.dat');
+        filesfound = 0;
+        for k=1:numel(filelist)
+            if regexp(filelist(k).name,['^meas_MID0*' num2str(measID) '_.*\.dat'])==1
+                if filesfound == 0
+                    filename = filelist(k).name;
+                end
+                filesfound = filesfound+1;
+            end
+        end
+        if filesfound == 0
+            error(['File with meas. id ' num2str(measID) ' not found.']);
+        elseif filesfound > 1
+            disp(['Multiple files with meas. id ' num2str(measID) ' found. Choosing first occurence.']);
+        end
+    end
+end
+
+% add absolute path, when no path is given
+[pathstr, name, ext] = fileparts(filename);
+
+if isempty(pathstr)
+    pathstr  = pwd;
+    filename = fullfile(pathstr, [name ext]);
+end
+
+%%%%% Parse varargin %%%%%
+arg.bReadImaScan    = true;
+arg.bReadNoiseScan  = true;
+arg.bReadPCScan     = true;
+arg.bReadRefScan    = true;
+arg.bReadRefPCScan  = true;
+arg.bReadRTfeedback = true;
+arg.bReadPhaseStab  = true;
+arg.bReadHeader     = true;
+
+k=1;
+while k <= numel(varargin)
+
+    if ~ischar(varargin{k})
+        error('string expected');
+    end
+
+    switch lower(varargin{k})
+        case {'readheader','readhdr','header','hdr'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.bReadHeader = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.bReadHeader = true;
+                k = k+1;
+            end
+        case {'removeos','rmos'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.removeOS = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.removeOS = true;
+                k = k+1;
+            end
+        case {'doaverage','doave','ave','average'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doAverage = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doAverage = true;
+                k = k+1;
+            end
+        case {'averagereps','averagerepetitions'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageReps = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageReps = true;
+                k = k+1;
+            end
+        case {'averagesets'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.averageSets = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.averageSets = true;
+                k = k+1;
+            end
+        case {'ignseg','ignsegments','ignoreseg','ignoresegments'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.ignoreSeg = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.ignoreSeg = true;
+                k = k+1;
+            end
+        case {'rampsampregrid','regrid'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.rampSampRegrid = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.rampSampRegrid = true;
+                k = k+1;
+            end
+        case {'rawdatacorrect','dorawdatacorrect'}
+            if numel(varargin) > k && ~ischar(varargin{k+1})
+                arg.doRawDataCorrect = logical(varargin{k+1});
+                k = k+2;
+            else
+                arg.doRawDataCorrect = true;
+                k = k+1;
+            end
+        otherwise
+            error('Argument not recognized.');
+    end
+end
+clear varargin
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+tic;
+fid = fopen(filename,'r','l','US-ASCII');
+
+% start of actual measurement data (sans header)
+fseek(fid,0,'bof');
+
+firstInt  = fread(fid,1,'uint32');
+secondInt = fread(fid,1,'uint32');
+
+% lazy software version check (VB or VD?)
+if and(firstInt < 10000, secondInt <= 64)
+    version = 'vd';
+    disp('Software version: VD (!?)');
+
+    % number of different scans in file stored in 2nd in
+    NScans = secondInt;
+    measID = fread(fid,1,'uint32');
+    fileID = fread(fid,1,'uint32');
+    % measOffset: points to beginning of header, usually at 10240 bytes
+    measOffset = fread(fid,1,'uint64');
+    measLength = fread(fid,1,'uint64');
+    fseek(fid,measOffset,'bof');
+    hdrLength  = fread(fid,1,'uint32');
+
+else
+    % in VB versions, the first 4 bytes indicate the beginning of the
+    % raw data part of the file
+    version  = 'vb';
+    disp('Software version: VB (!?)');
+    measOffset = 0;
+    hdrLength  = firstInt;
+    NScans     = 1; % VB does not support multiple scans in one file
+end
+datStart = measOffset + hdrLength;
+
+%SRY read data correction factors
+% do this for all VB datasets, so that the factors are available later
+% in the image_obj if the user chooses to set the correction flag
+if (strcmp(version, 'vb')) % not implemented/tested for vd, yet
+    frewind(fid);
+    while ( (ftell(fid) < datStart) && ~exist('rawfactors', 'var'))
+        line = fgetl(fid);
+        %find the section of the protocol
+        %note: the factors are also available in <ParamArray."CoilSelects">
+        %along with element name and FFT scale, but the parsing is
+        %significantly more difficult
+        if (~isempty(strfind(line, '<ParamArray."axRawDataCorrectionFactor">')))
+            while (ftell(fid) < datStart)
+                line = fgetl(fid);
+                %find the line with correction factors
+                %the factors are on the first line that begins with this
+                %pattern
+                if (~isempty(strfind(line, '{ {  { ')))
+                    line = strrep(line, '}  { } ', '0.0');
+                    line = strrep(line, '{', '');
+                    line = strrep(line, '}', '');
+                    rawfactors = textscan(line, '%f');
+                    rawfactors = rawfactors{1}; %textscan returns a 1x1 cell array
+                    % this does not work in this location because the MDHs
+                    % have not been parsed yet
+                    %                    if (length(rawfactors) ~= 2*max(image_obj.NCha))
+                    %                       error('Number of raw factors (%f) does not equal channel count (%d)', length(rawfactors)/2, image_obj.NCha);
+                    %                    end;
+                    if (mod(length(rawfactors),2) ~= 0)
+                        error('Error reading rawfactors');
+                    end;
+                    %note the transpose, this makes the vector
+                    %multiplication during the read easier
+                    arg.rawDataCorrectionFactors = rawfactors(1:2:end).' + 1i*rawfactors(2:2:end).';
+                    break;
+                end
+            end
+        end
+    end
+    disp('Read raw data correction factors');
+end
+
+% data will be read in two steps (two while loops):
+%   1) reading all MDHs to find maximum line no., partition no.,... for
+%      ima, ref,... scan
+%   2) reading the data
+tic;
+cPos            = measOffset;
+twix_obj        = cell(1,NScans);
+
+for s=1:NScans
+    fseek(fid,cPos,'bof');
+    hdr_len = fread(fid, 1,'uint32');
+
+    % read header and calculate regridding (optional)
+    rstraj = 1; %[];
+    if arg.bReadHeader
+        [twix_obj{s}.hdr,rstraj] = read_twix_hdr(fid);
+        rstraj = 1;
+    end
+
+    % declare data objects: DLP 7 Dec 2018: Changed this name (added _uk) because of
+    % changes to handle Siemens WIP MRTI sequence
+%     twix_obj{s}.image         = twix_map_obj_ukHO(arg,'image',filename,version,rstraj);
+%     twix_obj{s}.noise         = twix_map_obj_ukHO(arg,'noise',filename,version);
+%     twix_obj{s}.phasecor      = twix_map_obj_ukHO(arg,'phasecor',filename,version,rstraj);
+%     twix_obj{s}.phasestab     = twix_map_obj_ukHO(arg,'phasestab',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef0 = twix_map_obj_ukHO(arg,'phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.phasestabRef1 = twix_map_obj_ukHO(arg,'phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.refscan       = twix_map_obj_ukHO(arg,'refscan',filename,version,rstraj);
+%     twix_obj{s}.refscanPC     = twix_map_obj_ukHO(arg,'refscan_phasecor',filename,version,rstraj);
+%     twix_obj{s}.refscanPS     = twix_map_obj_ukHO(arg,'refscan_phasestab',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef0 = twix_map_obj_ukHO(arg,'refscan_phasestab_ref0',filename,version,rstraj);
+%     twix_obj{s}.refscanPSRef1 = twix_map_obj_ukHO(arg,'refscan_phasestab_ref1',filename,version,rstraj);
+%     twix_obj{s}.RTfeedback    = twix_map_obj_ukHO(arg,'rtfeedback',filename,version,rstraj);
+%     twix_obj{s}.vop           = twix_map_obj_ukHO(arg,'vop',filename,version); % tx-array rf pulses
+    twix_obj{s}.image         = twix_map_obj_ukHO(arg,'image',filename,version,rstraj);
+    twix_obj{s}.noise         = twix_map_obj_ukHO(arg,'noise',filename,version,rstraj);
+    twix_obj{s}.phasecor      = twix_map_obj_ukHO(arg,'phasecor',filename,version,rstraj);
+    twix_obj{s}.phasestab     = twix_map_obj_ukHO(arg,'phasestab',filename,version,rstraj);
+    twix_obj{s}.phasestabRef0 = twix_map_obj_ukHO(arg,'phasestab_ref0',filename,version,rstraj);
+    twix_obj{s}.phasestabRef1 = twix_map_obj_ukHO(arg,'phasestab_ref1',filename,version,rstraj);
+    twix_obj{s}.refscan       = twix_map_obj_ukHO(arg,'refscan',filename,version,rstraj);
+    twix_obj{s}.refscanPC     = twix_map_obj_ukHO(arg,'refscan_phasecor',filename,version,rstraj);
+    twix_obj{s}.refscanPS     = twix_map_obj_ukHO(arg,'refscan_phasestab',filename,version,rstraj);
+    twix_obj{s}.refscanPSRef0 = twix_map_obj_ukHO(arg,'refscan_phasestab_ref0',filename,version,rstraj);
+    twix_obj{s}.refscanPSRef1 = twix_map_obj_ukHO(arg,'refscan_phasestab_ref1',filename,version,rstraj);
+    twix_obj{s}.RTfeedback    = twix_map_obj_ukHO(arg,'rtfeedback',filename,version,rstraj);
+    twix_obj{s}.vop           = twix_map_obj_ukHO(arg,'vop',filename,version); % tx-array rf pulses
+
+
+    % jump to first mdh
+    cPos = cPos + hdr_len;
+    fseek( fid, cPos, 'bof' );
+
+    % find all mdhs and save them in binary form, first:
+    fprintf('Scan %d/%d, read all mdhs:\n', s, NScans )
+
+    [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version );  % uint8; size: [ byteMDH  Nmeas ]
+
+    cPos = filePos( end );
+    filePos( end ) = [];
+
+    fprintf('          parse mdhs... ')
+    t0 = tic;
+
+    % get mdhs and masks for each scan, no matter if noise, image, RTfeedback etc:
+    [mdh, mask] = evalMDH( mdh_blob, version ); % this is quasi-instant (< 1s) :-)    
+    clear mdh_blob
+
+    % Assign mdhs to their respective scans and parse it in the correct twix objects.
+    %
+    if arg.bReadImaScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_IMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.image.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadNoiseScan
+        clear tmpMdh
+        isCurrScan = logical( mask.MDH_NOISEADJSCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.noise.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRefScan
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN )...
+                     & ~( mask.MDH_PHASCOR | mask.MDH_PHASESTABSCAN | ...
+                          mask.MDH_REFPHASESTABSCAN | ...
+                          mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK);
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscan.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadRTfeedback
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK | mask.MDH_HPFEEDBACK ) & ~mask.MDH_VOP;
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.RTfeedback.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan = ( mask.MDH_RTFEEDBACK & mask.MDH_VOP );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.vop.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPCScan
+        % logic really correct?
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & ( ~mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasecor.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan = mask.MDH_PHASCOR & (  mask.MDH_PATREFSCAN | mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPC.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    if arg.bReadPhaseStab
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestab.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_PHASESTABSCAN & ~mask.MDH_REFPHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN    |  mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPS.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & ~mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef0.readMDH( tmpMdh, filePos(isCurrScan) );
+        
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & (~mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.phasestabRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+
+        clear tmpMdh
+        isCurrScan =    ( mask.MDH_REFPHASESTABSCAN & mask.MDH_PHASESTABSCAN ) ...
+                      & ( mask.MDH_PATREFSCAN   |   mask.MDH_PATREFANDIMASCAN );
+        for f = fieldnames( mdh ).'
+            tmpMdh.(f{1}) = mdh.(f{1})( isCurrScan, : );
+        end
+        twix_obj{s}.refscanPSRef1.readMDH( tmpMdh, filePos(isCurrScan) );
+    end
+    twix_obj{s}.hdr.ulTimeStamp = mdh.ulTimeStamp; % DEP 01/07/19
+    [twix_obj{s}.hdr.ulAcquisitionTimeStamp, twix_obj{s}.hdr.ulAcquisitionStrTimeStamp] = AcqTime(twix_obj{s}.hdr, 1); % DEP 01/08/09
+    clear  mdh  tmpMdh  filePos  isCurrScan
+
+    for scan = { 'image', 'noise', 'phasecor', 'phasestab', ...
+                 'phasestabRef0', 'phasestabRef1', 'refscan', ...
+                 'refscanPC', 'refscanPS', 'refscanPSRef0', ...
+                 'refscanPSRef1', 'RTfeedback', 'vop' }
+        f = scan{1};
+
+        % remove unused fields
+        if twix_obj{s}.(f).NAcq == 0
+            twix_obj{s} = rmfield(twix_obj{s}, f );
+        else
+            if isEOF
+                % recover from read error
+                twix_obj{s}.(f).tryAndFixLastMdh();
+            else
+                twix_obj{s}.(f).clean();
+            end
+        end
+    end
+    fprintf('done. (%g seconds)\n', toc(t0) )
+
+end % NScans loop
+
+if NScans == 1
+    twix_obj = twix_obj{1};
+end
+
+end % of mapVBVD()
+
+
+
+
+function [mdh_blob, filePos, isEOF] = loop_mdh_read( fid, version )
+% Goal of this function is to gather all mdhs in the dat file and store them
+% in binary form, first. This enables us to evaluate and parse the stuff in
+% a MATLAB-friendly (vectorized) way. We also yield a clear separation between
+% a lengthy loop and other expressions that are evaluated very few times.
+%
+% The main challenge is that we never know a priori, where the next mdh is
+% and how many there are. So we have to actually evaluate some mdh fields to
+% find the next one.
+%
+% All slow things of the parsing step are found in the while loop.
+% => It is the (only) place where micro-optimizations are worthwhile.
+%
+% The current state is that we are close to sequential disk I/O times.
+% More fancy improvements may be possible by using workers through parfeval()
+% or threads using a java class (probably faster + no toolbox):
+% http://undocumentedmatlab.com/blog/explicit-multi-threading-in-matlab-part1
+
+    switch version
+        case 'vb'
+            isVD    = false;
+            byteMDH = 128;
+        case 'vd'
+            isVD    = true;
+            byteMDH = 184;
+            szScanHeader    = 192; % [bytes]
+            szChannelHeader =  32; % [bytes]
+        otherwise
+            % arbitrary assumptions:
+            isVD    = false;
+            byteMDH = 128;
+            warning( [mfilename() ':UnknownVer'], 'Software version "%s" is not supported.', version );
+    end
+
+    cPos            = ftell(fid);
+    n_acq           = 0;
+    allocSize       = 4096;
+    ulDMALength     = byteMDH;
+    isEOF           = false;
+    percentFinished = 0;
+    progress_str    = '';
+    prevLength      = numel( progress_str );
+
+    mdh_blob = zeros( byteMDH, 0, 'uint8' );
+    szBlob   = size( mdh_blob, 2 );
+    filePos  = zeros(0, 1, class(cPos));  % avoid bug in Matlab 2013b: https://scivision.co/matlab-fseek-bug-with-uint64-offset/
+
+    % get file size
+    fseek(fid,0,'eof');
+    fileSize = ftell(fid);
+    fseek(fid,cPos,'bof');
+
+    % ======================================
+    %   constants and conditional variables
+    % ======================================
+        bit_0 = uint8(2^0);
+        bit_5 = uint8(2^5);
+        mdhStart = 1-byteMDH;
+        
+        u8_000 = zeros( 3, 1, 'uint8'); % for comparison with data_u8(1:3)
+
+        % 20 fill bytes in VD (21:40)
+        evIdx   = uint8(    21  + 20*isVD); % 1st byte of evalInfoMask
+        dmaIdx  = uint8((29:32) + 20*isVD); % to correct DMA length using NCol and NCha
+        if isVD
+            dmaOff  = szScanHeader;
+            dmaSkip = szChannelHeader;
+        else
+            dmaOff  = 0;
+            dmaSkip = byteMDH;
+        end
+    % ======================================
+
+    t0 = tic;
+    while true
+        % Read mdh as binary (uint8) and evaluate as little as possible to know...
+        %   ... where the next mdh is (ulDMALength / ushSamplesInScan & ushUsedChannels)
+        %   ... whether it is only for sync (MDH_SYNCDATA)
+        %   ... whether it is the last one (MDH_ACQEND)
+        % evalMDH() contains the correct and readable code for all mdh entries.
+        try
+            % read everything and cut out the mdh
+            data_u8 = fread( fid, ulDMALength, 'uint8=>uint8' );
+            data_u8 = data_u8( mdhStart+end :  end );
+        catch exc
+            warning( [mfilename() ':UnxpctdEOF'],  ...
+                      [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                        'Will stop reading now.\n'                                             ...
+                        '=== MATLABs error message ================\n'                         ...
+                        exc.message                                                            ...
+                        '\n=== end of error =========================\n'                       ...
+                       ], cPos, cPos/1024^3 )
+            isEOF = true;
+            break
+        end
+
+        bitMask = data_u8(evIdx);   % the initial 8 bit from evalInfoMask are enough
+
+        if   isequal( data_u8(1:3), u8_000 )    ... % probably ulDMALength == 0
+          || bitand(bitMask, bit_0);                % MDH_ACQEND
+
+            % ok, look closer if really all *4* bytes are 0:
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+
+            if ulDMALength == 0 || bitand(bitMask, bit_0)
+                cPos = cPos + ulDMALength;
+                % jump to next full 512 bytes
+                if mod(cPos,512)
+                    cPos = cPos + 512 - mod(cPos,512);
+                end
+                break;
+            end
+        end
+        if bitand(bitMask, bit_5);  % MDH_SYNCDATA
+            data_u8(4)= bitget( data_u8(4),1);  % ubit24: keep only 1 bit from the 4th byte
+            ulDMALength = double( typecast( data_u8(1:4), 'uint32' ) );
+            cPos = cPos + ulDMALength;
+            continue
+        end
+
+        % pehses: the pack bit indicates that multiple ADC are packed into one
+        % DMA, often in EPI scans (controlled by fRTSetReadoutPackaging in IDEA)
+        % since this code assumes one adc (x NCha) per DMA, we have to correct
+        % the "DMA length"
+        %     if mdh.ulPackBit
+        % it seems that the packbit is not always set correctly
+        NCol_NCha = double( typecast( data_u8(dmaIdx), 'uint16' ) );  % [ushSamplesInScan  ushUsedChannels]
+        ulDMALength = dmaOff + (8*NCol_NCha(1) + dmaSkip) * NCol_NCha(2);
+
+        n_acq = n_acq + 1;
+
+        % grow arrays in batches
+        if n_acq > szBlob
+            mdh_blob( :, end + allocSize ) = 0;
+            filePos( end + allocSize ) = 0;
+            szBlob = size( mdh_blob, 2 );
+        end
+        mdh_blob(:,n_acq) = data_u8;
+        filePos( n_acq )  = cPos;
+
+        if (100*cPos)/fileSize > percentFinished + 1
+            percentFinished = floor((100*cPos)/fileSize);
+            elapsed_time    = toc(t0);
+            time_left       = (fileSize/cPos-1) * elapsed_time;
+            prevLength      = numel(progress_str);
+            progress_str    = sprintf('    %3.0f %% read in %4.0f s; estimated time left: %4.0f s \n',...
+                                      percentFinished,elapsed_time, time_left);
+            fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+        end
+
+        cPos = cPos + ulDMALength;
+    end % while true
+
+    if isEOF
+        n_acq = n_acq-1;    % ignore the last attempt
+    end
+
+    filePos( n_acq+1 ) = cPos;  % save pointer to the next scan
+
+    % discard overallocation:
+    mdh_blob = mdh_blob(:,1:n_acq);
+    filePos  = reshape( filePos(1:n_acq+1), 1, [] ); % row vector
+
+    prevLength   = numel(progress_str) * (~isEOF);
+    elapsed_time = toc(t0);
+    progress_str = sprintf('    100 %% read in %4.0f s; estimated time left:    0 s \n', elapsed_time);
+    fprintf([repmat('\b',1,prevLength) '%s'],progress_str);
+
+end % of loop_mdh_read()
+
+
+
+function [mdh,mask] = evalMDH( mdh_blob, version )
+% see pkg/MrServers/MrMeasSrv/SeqIF/MDH/mdh.h
+% and pkg/MrServers/MrMeasSrv/SeqIF/MDH/MdhProxy.h
+
+if ~isa( mdh_blob, 'uint8' )
+    error( [mfilename() ':NoInt8'], 'Binary mdh data must be a uint8 array!' )
+end
+
+if version(end) == 'd'
+    isVD = true;
+    mdh_blob = mdh_blob([1:20 41:end], :);     % remove 20 unnecessary bytes
+else
+    isVD = false;
+end
+
+Nmeas   = size( mdh_blob, 2 );
+
+mdh.ulPackBit   = bitget( mdh_blob(4,:), 2).';
+mdh.ulPCI_rx    = bitset(bitset(mdh_blob(4,:), 7, 0), 8, 0).'; % keep 6 relevant bits
+mdh_blob(4,:)   = bitget( mdh_blob(4,:),1);  % ubit24: keep only 1 bit from the 4th byte
+
+% unfortunately, typecast works on vectors, only
+data_uint32     = typecast( reshape(mdh_blob(1:76,:),  [],1), 'uint32' );
+data_uint16     = typecast( reshape(mdh_blob(29:end,:),[],1), 'uint16' );
+data_single     = typecast( reshape(mdh_blob(69:end,:),[],1), 'single' );
+
+data_uint32 = reshape( data_uint32, [], Nmeas ).';
+data_uint16 = reshape( data_uint16, [], Nmeas ).';
+data_single = reshape( data_single, [], Nmeas ).';
+                                                        %  byte pos.
+%mdh.ulDMALength               = data_uint32(:,1);      %   1 :   4
+mdh.lMeasUID                   = data_uint32(:,2);      %   5 :   8
+mdh.ulScanCounter              = data_uint32(:,3);      %   9 :  12
+mdh.ulTimeStamp                = data_uint32(:,4);      %  13 :  16
+mdh.ulPMUTimeStamp             = data_uint32(:,5);      %  17 :  20
+mdh.aulEvalInfoMask            = data_uint32(:,6:7);    %  21 :  28
+mdh.ushSamplesInScan           = data_uint16(:,1);      %  29 :  30
+mdh.ushUsedChannels            = data_uint16(:,2);      %  31 :  32
+mdh.sLC                        = data_uint16(:,3:16);   %  33 :  60
+mdh.sCutOff                    = data_uint16(:,17:18);  %  61 :  64
+mdh.ushKSpaceCentreColumn      = data_uint16(:,19);     %  66 :  66
+mdh.ushCoilSelect              = data_uint16(:,20);     %  67 :  68
+mdh.fReadOutOffcentre          = data_single(:, 1);     %  69 :  72
+mdh.ulTimeSinceLastRF          = data_uint32(:,19);     %  73 :  76
+mdh.ushKSpaceCentreLineNo      = data_uint16(:,25);     %  77 :  78
+mdh.ushKSpaceCentrePartitionNo = data_uint16(:,26);     %  79 :  80
+
+if isVD
+    mdh.SlicePos                    = data_single(:, 4:10); %  81 : 108
+    mdh.aushIceProgramPara          = data_uint16(:,41:64); % 109 : 156
+    mdh.aushFreePara                = data_uint16(:,65:68); % 157 : 164
+else
+    mdh.aushIceProgramPara          = data_uint16(:,27:30); %  81 :  88
+    mdh.aushFreePara                = data_uint16(:,31:34); %  89 :  96
+    mdh.SlicePos                    = data_single(:, 8:14); %  97 : 124
+end
+
+% inlining of evalInfoMask
+evalInfoMask1 = mdh.aulEvalInfoMask(:,1);
+mask.MDH_ACQEND             = min(bitand(evalInfoMask1, 2^0), 1);
+mask.MDH_RTFEEDBACK         = min(bitand(evalInfoMask1, 2^1), 1);
+mask.MDH_HPFEEDBACK         = min(bitand(evalInfoMask1, 2^2), 1);
+mask.MDH_SYNCDATA           = min(bitand(evalInfoMask1, 2^5), 1);
+mask.MDH_RAWDATACORRECTION  = min(bitand(evalInfoMask1, 2^10),1);
+mask.MDH_REFPHASESTABSCAN   = min(bitand(evalInfoMask1, 2^14),1);
+mask.MDH_PHASESTABSCAN      = min(bitand(evalInfoMask1, 2^15),1);
+mask.MDH_SIGNREV            = min(bitand(evalInfoMask1, 2^17),1);
+mask.MDH_PHASCOR            = min(bitand(evalInfoMask1, 2^21),1);
+mask.MDH_PATREFSCAN         = min(bitand(evalInfoMask1, 2^22),1);
+mask.MDH_PATREFANDIMASCAN   = min(bitand(evalInfoMask1, 2^23),1);
+mask.MDH_REFLECT            = min(bitand(evalInfoMask1, 2^24),1);
+mask.MDH_NOISEADJSCAN       = min(bitand(evalInfoMask1, 2^25),1);
+mask.MDH_VOP                = min(bitand(mdh.aulEvalInfoMask(2), 2^(53-32)),1); % was 0 in VD
+
+mask.MDH_IMASCAN            = ones( Nmeas, 1, 'uint32' );
+
+noImaScan = (   mask.MDH_ACQEND             | mask.MDH_RTFEEDBACK   | mask.MDH_HPFEEDBACK       ...
+              | mask.MDH_PHASCOR            | mask.MDH_NOISEADJSCAN | mask.MDH_PHASESTABSCAN    ...
+              | mask.MDH_REFPHASESTABSCAN   | mask.MDH_SYNCDATA                                 ... 
+              | (mask.MDH_PATREFSCAN & ~mask.MDH_PATREFANDIMASCAN) );
+
+mask.MDH_IMASCAN( noImaScan ) = 0;
+
+end % of evalMDH()

--- a/matlab/read_kspace_dependencies/mapVBVD/read_twix_hdr.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/read_twix_hdr.m
@@ -1,0 +1,144 @@
+function [prot,rstraj] = read_twix_hdr(fid)
+% function to read raw data header information from siemens MRI scanners 
+% (currently VB and VD software versions are supported and tested).
+%
+% Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de), Mar/11/2014
+      
+    nbuffers = fread(fid, 1,'uint32');
+    
+    prot = [];
+    for b=1:nbuffers
+        namesz  = 0;
+        byte = 1;
+        while byte~=0 % look for NULL-character
+            byte   = fread(fid, 1, 'uint8');
+            namesz = namesz+1;
+        end
+        fseek(fid,-namesz,'cof');
+        bufname        = fread(fid,namesz,'char=>char').';
+        bufname(end)   = []; % delete NULL character
+        buflen         = fread(fid, 1,'uint32');
+        buffer         = fread(fid, buflen, 'char=>char').';
+        buffer         = regexprep(buffer,'\n\s*\n',''); % delete empty lines
+        prot.(bufname) = parse_buffer(buffer);
+    end
+    
+    if nargout>1
+        rstraj = [];
+        if isfield(prot.Meas,'alRegridMode') && prot.Meas.alRegridMode(1)>1
+            ncol           = prot.Meas.alRegridDestSamples(1);
+            dwelltime      = prot.Meas.aflRegridADCDuration(1)/ncol;
+            gr_adc         = zeros(1,ncol,'single');
+            time_adc       = prot.Meas.alRegridDelaySamplesTime(1) + dwelltime * (0.5:ncol);
+            ixUp           = time_adc <= prot.Meas.alRegridRampupTime(1);
+            ixFlat         = (time_adc <= prot.Meas.alRegridRampupTime(1)+prot.Meas.alRegridFlattopTime(1)) & ~ixUp;
+            ixDn           = ~ixUp & ~ixFlat;
+            gr_adc(ixFlat) = 1;
+            if prot.Meas.alRegridMode(1) == 2  
+                % trapezoidal gradient
+                gr_adc(ixUp)   = time_adc(ixUp)/prot.Meas.alRegridRampupTime(1);
+                gr_adc(ixDn)   = 1 - (time_adc(ixDn)-prot.Meas.alRegridRampupTime(1)-prot.Meas.alRegridFlattopTime(1))/prot.Meas.alRegridRampdownTime(1);
+            elseif prot.Meas.alRegridMode(1) == 4  
+                % sinusoidal gradient
+                gr_adc(ixUp)   = sin(pi/2*time_adc(ixUp)/prot.Meas.alRegridRampupTime(1));
+                gr_adc(ixDn)   = sin(pi/2*(1+(time_adc(ixDn)-prot.Meas.alRegridRampupTime(1)-prot.Meas.alRegridFlattopTime(1))/prot.Meas.alRegridRampdownTime(1)));
+            else
+                warning('regridding mode unknown');
+                return;
+            end
+            % make sure that gr_adc is always positive (rstraj needs to be
+            % strictly monotonic):
+            gr_adc = max(gr_adc,1e-4);
+            rstraj = (cumsum(gr_adc(:)) - ncol/2)/sum(gr_adc(:));
+            rstraj = rstraj - rstraj(ncol/2+1);
+        end
+    end
+    
+end        
+    
+function prot = parse_buffer(buffer)
+    [ascconv,xprot] = regexp(buffer,'### ASCCONV BEGIN[^\n]*\n(.*)\s### ASCCONV END ###','tokens','split');
+
+    if ~isempty(ascconv)
+        ascconv = ascconv{:}{:};
+        prot = parse_ascconv(ascconv);
+    else
+        prot = struct();
+    end
+
+    if ~isempty(xprot)
+        xprot = xprot{:};
+        xprot = parse_xprot(xprot);
+        if isstruct(xprot)
+            name   = cat(1,fieldnames(prot),fieldnames(xprot));
+            val    = cat(1,struct2cell(prot),struct2cell(xprot));
+            [~,ix] = unique(name);
+            prot   = cell2struct(val(ix),name(ix));
+        end
+    end
+end
+
+function xprot = parse_xprot(buffer)
+    xprot = [];
+    tokens = regexp(buffer, '<Param(?:Bool|Long|String)\."(\w+)">\s*{([^}]*)','tokens');
+    tokens = [tokens, regexp(buffer, '<ParamDouble\."(\w+)">\s*{\s*(<Precision>\s*[0-9]*)?\s*([^}]*)','tokens')];
+    for m=1:numel(tokens)
+        name         = char(tokens{m}(1));
+        % field name has to start with letter
+        if (~isletter(name(1)))
+            name = strcat('x', name);
+        end
+
+        value = char(strtrim(regexprep(tokens{m}(end), '("*)|( *<\w*> *[^\n]*)', '')));
+        value = regexprep(value, '\s*', ' ');
+
+        try %#ok<TRYNC>
+            value = eval(['[' value ']']);  % inlined str2num()
+        end
+
+        xprot.(name) = value;
+    end
+end
+
+function mrprot = parse_ascconv(buffer)  
+    mrprot = [];    
+    % [mv] was: vararray = regexp(buffer,'(?<name>\S*)\s*=\s(?<value>\S*)','names');
+    vararray = regexp(buffer,'(?<name>\S*)\s*=\s*(?<value>\S*)','names');
+    
+    for var=vararray
+
+        try
+            value = eval(['[' var.value ']']);  % inlined str2num()
+        catch
+            value = var.value;
+        end
+        
+        % now split array name and index (if present)
+        v = regexp(var.name,'(?<name>\w*)\[(?<ix>[0-9]*)\]|(?<name>\w*)','names');
+
+        cnt = 0;
+        tmp = cell(2,numel(v));
+
+        breaked = false;
+        for k=1:numel(v)
+            if ~isletter(v(k).name(1))
+                breaked = true;
+                break;
+            end
+            cnt = cnt+1;
+            tmp{1,cnt} = '.';
+            tmp{2,cnt} = v(k).name;
+
+            if ~isempty(v(k).ix)
+                cnt = cnt+1;
+                tmp{1,cnt} = '{}';
+                tmp{2,cnt}{1} = 1 + str2double(v(k).ix);
+            end
+        end
+        if ~breaked && ~isempty(tmp)
+            S = substruct(tmp{:});
+            mrprot = subsasgn(mrprot,S,value);
+        end
+    end 
+end
+

--- a/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj.m
@@ -1,0 +1,1072 @@
+classdef twix_map_obj < matlab.mixin.Copyable %handle
+% class to hold information about raw data from siemens MRI scanners
+% (currently VB and VD software versions are supported and tested).
+%
+% Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de), Aug/19/2011
+%
+%
+% Modified by Wolf Blecher (wolf.blecher@tuebingen.mpg.de), Apr/26/2012
+% Added reorder index to indicate which lines are reflected
+% Added slice position for sorting, Mai/15/2012
+%
+% Order of many mdh parameters are now stored (including the reflected ADC
+% bit); PE, Jun/14/2012
+%
+% data is now 'memory mapped' and not read until demanded;
+% (see mapVBVD for a description) PE, Aug/02/2012
+%
+% twix_obj.image.unsorted now returns the data in its acq. order
+% [NCol,NCha,nsamples in acq. order], all average flags don't have an
+% influence on the output, but 'flagRemoveOS' still works, PE, Sep/04/13
+%
+properties(Dependent=true)
+    % flags
+    flagRemoveOS        % removes oversampling in read (col) during read operation
+    flagDoAverage       % averages over all avg during read operation
+    flagAverageReps     % averages over all repetitions
+    flagAverageSets     % averages over all sets
+    flagIgnoreSeg       % sum over all segments during read operation
+    flagSkipToFirstLine % skips lines/partitions up to the first
+                        % actually acquired line/partition
+                        % (e.g. only the center k-space is acquired in
+                        % refscans, we don't want all the leading zeros
+                        % in our data)
+                        % this is the default behaviour for everything
+                        % but image scans (but can be changed manually)
+    flagRampSampRegrid  % perform on-the-fly ramp sampling regridding
+    flagDoRawDataCorrect     %SRY: apply raw data correction factors during read operation
+    
+    RawDataCorrectionFactors %SRY: allow the user to set/get the factors
+end
+
+properties(GetAccess='public', SetAccess='public')
+    flagAverageDim      % new: flags that determines whether certain dim. should be averaged/ignored
+    filename
+    softwareVersion
+    dataType
+end
+
+properties(Dependent=true)
+    dataSize % this is the current output size, depends on fullSize + some flags
+    sqzSize
+end
+
+properties(GetAccess='public', SetAccess='protected')
+    dataDims
+    sqzDims
+
+    NCol  % mdh information
+    NCha  % mdh information
+    NLin  % mdh information
+    NPar  % mdh information
+    NSli  % mdh information
+    NAve  % mdh information
+    NPhs  % mdh information
+    NEco  % mdh information
+    NRep  % mdh information
+    NSet  % mdh information
+    NSeg  % mdh information
+    NIda  % mdh information
+    NIdb  % mdh information
+    NIdc  % mdh information
+    NIdd  % mdh information
+    NIde  % mdh information
+    NAcq  % simple counter
+
+    % mdh information
+    Lin
+    Par
+    Sli
+    Ave
+    Phs
+    Eco
+    Rep
+    Set
+    Seg
+    Ida
+    Idb
+    Idc
+    Idd
+    Ide
+
+    centerCol
+    centerLin
+    centerPar
+    cutOff
+    coilSelect
+    ROoffcenter
+    timeSinceRF
+    IsReflected
+    IsRawDataCorrect %SRY: storage for MDH flag raw data correct
+
+    slicePos
+    freeParam
+    iceParam
+    scancounter
+    timestamp
+    pmutime
+    rampSampTrj
+
+    % memory position in file
+    memPos
+    
+    isBrokenFile % errors when parsing? 
+end
+
+properties(Hidden=true, SetAccess='protected')
+    arg  % arguments
+
+    fullSize % this is the full size of the data set according to the mdhs, i.e. flags
+             % like 'reduceOS' have no influence on it
+
+    freadInfo
+
+    skipLin
+    skipPar
+end
+
+methods
+    % Constructor:
+    function this = twix_map_obj(arg,dataType,fname,version,rstraj)
+
+        if ~exist('dataType','var')
+            this.dataType = 'image';
+        else
+            this.dataType = lower(dataType);
+        end
+
+        this.filename         = fname;
+        this.softwareVersion  = version;
+
+        this.IsReflected      = logical([]);
+        this.IsRawDataCorrect = logical([]); %SRY
+        this.NAcq             = 0;
+        this.isBrokenFile     = false;
+
+        this.setDefaultFlags();
+        if exist('arg','var')
+            % copy relevant arguments from mapVBVD argument list
+            names=fieldnames(arg);
+            for k=1:numel(names)
+                if isfield(this.arg,names{k})
+                    this.arg.(names{k}) = arg.(names{k});
+                end
+            end
+        end
+        this.flagAverageDim(ismember(this.dataDims,'Ave')) = this.arg.doAverage;
+        this.flagAverageDim(ismember(this.dataDims,'Rep')) = this.arg.averageReps;
+        this.flagAverageDim(ismember(this.dataDims,'Set')) = this.arg.averageSets;
+        this.flagAverageDim(ismember(this.dataDims,'Seg')) = this.arg.ignoreSeg;
+        
+        switch this.softwareVersion
+            case 'vb'
+                % every channel has its own full mdh
+                this.freadInfo.szScanHeader    =   0; % [bytes]
+                this.freadInfo.szChannelHeader = 128; % [bytes]
+                this.freadInfo.iceParamSz      =   4;
+            case 'vd'
+                if ( this.arg.doRawDataCorrect )
+                    error('raw data correction for VD not supported/tested yet');
+                end
+                this.freadInfo.szScanHeader    = 192; % [bytes]
+                this.freadInfo.szChannelHeader =  32; % [bytes]
+                this.freadInfo.iceParamSz      =  24; % vd version supports up to 24 ice params
+            otherwise
+                error('software version not supported');
+        end
+
+        if exist('rstraj','var')
+            this.rampSampTrj = rstraj;
+        else
+            this.rampSampTrj        = [];
+            this.arg.rampSampRegrid = false;
+        end
+    end
+
+    function this = readMDH(this, mdh, filePos )
+        % extract all values in all MDHs at once
+        %
+        % data types:
+        % Use double for everything non-logical, both ints and floats. Seems the
+        % most robust way to avoid unexpected cast-issues with very nasty side effects.
+        % Examples: eps(single(16777216)) == 2
+        %           uint32( 10 ) - uint32( 20 ) == 0
+        %           uint16(100) + 1e5 == 65535
+        %           size(1 : 10000 * uint16(1000)) ==  [1  65535]
+        %
+        % The 1st example always hits the timestamps.
+
+        if ~isstruct( mdh ) || isempty( mdh )
+            return
+        end
+
+        this.NAcq     = numel( filePos );
+        sLC           = double( mdh.sLC ) + 1;  % +1: convert to matlab index style
+        evalInfoMask1 = double( mdh.aulEvalInfoMask(:,1) ).';
+
+        % save mdh information for each line
+        this.NCol       = double( mdh.ushSamplesInScan ).';
+        this.NCha       = double( mdh.ushUsedChannels ).';
+        this.Lin        = sLC(:,1).' ;
+        this.Ave        = sLC(:,2).' ;
+        this.Sli        = sLC(:,3).' ;
+        this.Par        = sLC(:,4).' ;
+        this.Eco        = sLC(:,5).' ;
+        this.Phs        = sLC(:,6).' ;
+        this.Rep        = sLC(:,7).' ;
+        this.Set        = sLC(:,8).' ;
+        this.Seg        = sLC(:,9).' ;
+        this.Ida        = sLC(:,10).';
+        this.Idb        = sLC(:,11).';
+        this.Idc        = sLC(:,12).';
+        this.Idd        = sLC(:,13).';
+        this.Ide        = sLC(:,14).';
+
+        this.centerCol   = double( mdh.ushKSpaceCentreColumn ).' + 1;
+        this.centerLin   = double( mdh.ushKSpaceCentreLineNo ).' + 1;
+        this.centerPar   = double( mdh.ushKSpaceCentrePartitionNo ).' + 1;
+        this.cutOff      = double( mdh.sCutOff ).';
+        this.coilSelect  = double( mdh.ushCoilSelect ).';
+        this.ROoffcenter = double( mdh.fReadOutOffcentre ).';
+        this.timeSinceRF = double( mdh.ulTimeSinceLastRF ).';
+        this.IsReflected = logical(min(bitand(evalInfoMask1,2^24),1));
+        this.scancounter = double( mdh.ulScanCounter ).';
+        this.timestamp   = double( mdh.ulTimeStamp ).';
+        this.pmutime     = double( mdh.ulPMUTimeStamp ).';
+        this.IsRawDataCorrect = logical(min(bitand(evalInfoMask1,2^10),1)); %SRY
+        this.slicePos    = double( mdh.SlicePos ).';
+        this.iceParam    = double( mdh.aushIceProgramPara ).';
+        this.freeParam   = double( mdh.aushFreePara ).';
+
+        this.memPos = filePos;
+
+    end % of readMDH
+
+    function this = tryAndFixLastMdh(this)
+        eofWarning = [mfilename() ':UnxpctdEOF'];   % We have it inside this.readData()
+        warning( 'off', eofWarning )    % silence warnings for read...
+        warning( 'off', 'foo:bar'  )    % ... and a stupid placeholder
+
+        isLastAcqGood = false;
+        cnt = 0;
+
+        while ~isLastAcqGood  &&  this.NAcq > 0  && cnt < 100
+            warning( 'foo:bar', 'baz') % make sure that lastwarn() does not return eofWarning
+            try
+                this.clean();
+                this.unsorted(this.NAcq);
+                [~, warnid] = lastwarn();
+                if strcmp( warnid, eofWarning )
+                    error( 'Make sure to go to the catch block.')
+                end
+                isLastAcqGood = true;
+            catch
+                this.isBrokenFile = true;
+                this.NAcq = this.NAcq-1;
+            end
+            cnt = cnt + 1;
+        end
+        
+%         if this.NAcq == 0  ||  cnt > 99    % everything is garbage
+%             warning(  )
+%         end
+
+        warning( 'on', eofWarning )
+    end
+
+    function this = clean(this)
+        
+        if this.NAcq == 0
+            return;
+        end
+
+        % Cut mdh data to actual size. Maybe we rejected acquisitions at the end
+        % due to read errors.
+        fields = { 'NCol', 'NCha',                                                  ...
+                   'Lin', 'Par', 'Sli', 'Ave', 'Phs', 'Eco', 'Rep',                 ...
+                   'Set', 'Seg', 'Ida', 'Idb', 'Idc', 'Idd', 'Ide',                 ...
+                   'centerCol'  ,   'centerLin',   'centerPar',           'cutOff', ...
+                   'coilSelect' , 'ROoffcenter', 'timeSinceRF',      'IsReflected', ...
+                   'scancounter',   'timestamp',     'pmutime', 'IsRawDataCorrect', ...
+                   'slicePos'   ,    'iceParam',   'freeParam',           'memPos'  };
+        
+        nack = this.NAcq;
+        idx = 1:nack;
+
+        for f = fields
+            f1 = f{1};
+            if size(this.(f1),2) > nack   % rarely
+                this.(f1) = this.(f1)(:,idx);       % 1st dim: samples,  2nd dim acquisitions
+            end
+        end
+
+        this.NLin = max(this.Lin);
+        this.NPar = max(this.Par);
+        this.NSli = max(this.Sli);
+        this.NAve = max(this.Ave);
+        this.NPhs = max(this.Phs);
+        this.NEco = max(this.Eco);
+        this.NRep = max(this.Rep);
+        this.NSet = max(this.Set);
+        this.NSeg = max(this.Seg);
+        this.NIda = max(this.Ida);
+        this.NIdb = max(this.Idb);
+        this.NIdc = max(this.Idc);
+        this.NIdd = max(this.Idd);
+        this.NIde = max(this.Ide);
+
+        % ok, let us assume for now that all NCol and NCha entries are
+        % the same for all mdhs:
+        this.NCol = this.NCol(1);
+        this.NCha = this.NCha(1);
+
+        this.dataDims = {'Col','Cha','Lin','Par','Sli','Ave','Phs',...
+            'Eco','Rep','Set','Seg','Ida','Idb','Idc','Idd','Ide'};
+
+        if strcmp(this.dataType,'refscan')
+            %pehses: check for lines with 'negative' line/partition numbers
+            %this can happen when the reference scan line/partition range
+            %exceeds the one of the actual imaging scan
+            if this.NLin>65500  %uint overflow check
+                this.Lin  = mod(this.Lin + (65536 - min(this.Lin(this.Lin>65500))),65536)+1;
+                this.NLin = max(this.Lin);
+            end
+            if this.NPar>65500  %uint overflow check
+                this.Par  = mod(this.Par + (65536 - min(this.Par(this.Par>65500))),65536)+1;
+                this.NPar = max(this.Par);
+            end
+        end
+
+        % to reduce the matrix sizes of non-image scans, the size
+        % of the refscan_obj()-matrix is reduced to the area of the
+        % actually scanned acs lines (the outer part of k-space
+        % that is not scanned is not filled with zeros)
+        % this behaviour is controlled by flagSkipToFirstLine which is
+        % set to true by default for everything but image scans
+        if ~this.flagSkipToFirstLine
+            % the output matrix should include all leading zeros
+            this.skipLin = 0;
+            this.skipPar = 0;
+        else
+            % otherwise, cut the matrix size to the start of the
+            % first actually scanned line/partition (e.g. the acs/
+            % phasecor data is only acquired in the k-space center)
+            this.skipLin = min(this.Lin)-1;
+            this.skipPar = min(this.Par)-1;
+        end
+        NLinAlloc = max(1, this.NLin - this.skipLin);
+        NParAlloc = max(1, this.NPar - this.skipPar);
+
+        this.fullSize = [ this.NCol this.NCha NLinAlloc NParAlloc...
+                          this.NSli this.NAve this.NPhs this.NEco...
+                          this.NRep this.NSet this.NSeg this.NIda...
+                          this.NIdb this.NIdc this.NIdd this.NIde ];
+
+        nByte = this.NCha*(this.freadInfo.szChannelHeader+8*this.NCol);
+
+        % size for fread
+        this.freadInfo.sz    = [2 nByte/8];
+        % reshape size
+        this.freadInfo.shape = [this.NCol+this.freadInfo.szChannelHeader/8 ...
+                               , this.NCha];
+        % we need to cut MDHs from fread data
+        this.freadInfo.cut   = this.freadInfo.szChannelHeader/8 + (1 : this.NCol);
+
+    end % of clean
+
+
+    function varargout = subsref(this, S)
+        % this is where the magic happens
+        % Now seriously. Overloading of the subsref-method and working
+        % with a gazillion indices got really messy really fast. At
+        % some point, I should probably clean this code up a bit. But
+        % good news everyone: It seems to work.
+        switch S(1).type
+            case '.'
+                % We don't want to manage method/variable calls, so we'll
+                % simply call the built-in subsref-function in this case.
+                if nargout == 0
+                    varargout{1} = builtin('subsref', this, S); % CTR fix.
+                else
+                    varargout      = cell(1, nargout);
+                    [varargout{:}] = builtin('subsref', this, S);
+                end
+                return;
+            case {'()','{}'}
+            otherwise
+                error('operator not supported');
+        end
+
+        [selRange,selRangeSz,outSize] = this.calcRange(S(1));
+
+    	% calculate page table (virtual to physical addresses)
+        % this is now done every time, i.e. result is no longer saved in
+        % a property - slower but safer (and easier to keep track of updates)
+        ixToRaw = this.calcIndices;
+        
+        tmp = reshape(1:prod(double(this.fullSize(3:end))), this.fullSize(3:end));
+        tmp = tmp(selRange{3:end});
+        ixToRaw = ixToRaw(tmp); clear tmp;
+        ixToRaw = ixToRaw(:);
+        % delete all entries that point to zero (the "NULL"-pointer)
+        notAcquired = (ixToRaw == 0);
+        ixToRaw (notAcquired) = []; clear notAcquired;
+
+        % calculate ixToTarg for possibly smaller, shifted + segmented
+        % target matrix:
+        cIx = ones(14, numel(ixToRaw), 'single');
+        if ~this.flagAverageDim(3)
+            cIx( 1,:) = this.Lin(ixToRaw) - this.skipLin;
+        end
+        if ~this.flagAverageDim(4)
+            cIx( 2,:) = this.Par(ixToRaw) - this.skipPar;
+        end
+        if ~this.flagAverageDim(5)
+            cIx( 3,:) = this.Sli(ixToRaw);
+        end
+        if ~this.flagAverageDim(6)
+            cIx( 4,:) = this.Ave(ixToRaw);
+        end
+        if ~this.flagAverageDim(7)
+            cIx( 5,:) = this.Phs(ixToRaw);
+        end
+        if ~this.flagAverageDim(8)
+            cIx( 6,:) = this.Eco(ixToRaw);
+        end
+        if ~this.flagAverageDim(9)
+            cIx( 7,:) = this.Rep(ixToRaw);
+        end
+        if ~this.flagAverageDim(10)
+            cIx( 8,:) = this.Set(ixToRaw);
+        end
+        if ~this.flagAverageDim(11)
+            cIx( 9,:) = this.Seg(ixToRaw);
+        end
+        if ~this.flagAverageDim(12)
+            cIx(10,:) = this.Ida(ixToRaw);
+        end
+        if ~this.flagAverageDim(13)
+            cIx(11,:) = this.Idb(ixToRaw);
+        end
+        if ~this.flagAverageDim(14)
+            cIx(12,:) = this.Idc(ixToRaw);
+        end
+        if ~this.flagAverageDim(15)
+            cIx(13,:) = this.Idd(ixToRaw);
+        end
+        if ~this.flagAverageDim(16)
+            cIx(14,:) = this.Ide(ixToRaw);
+        end
+
+        % make sure that indices fit inside selection range
+        for k=3:numel(selRange)
+            tmp = cIx(k-2,:);
+            for l=1:numel(selRange{k})
+                cIx(k-2,tmp==selRange{k}(l)) = l;
+            end
+        end
+
+        ixToTarg = this.sub2ind_double(selRangeSz(3:end),cIx(1,:),cIx(2,:),cIx(3,:),...
+            cIx(4,:),cIx(5,:),cIx(6,:),cIx(7,:),cIx(8,:),cIx(9,:),...
+            cIx(10,:),cIx(11,:),cIx(12,:),cIx(13,:),cIx(14,:));
+
+        mem = this.memPos(ixToRaw);
+        % sort mem for quicker access, sort cIxToTarg/Raw accordingly
+        [mem,ix]  = sort(mem);
+        ixToTarg = ixToTarg(ix);
+        ixToRaw  = ixToRaw(ix);
+        clear ix;
+
+        % For a call of type data{:,:,1:3} matlab expects more than one
+        % output variable (three in this case) and will throw an error
+        % otherwise. This is a lazy way (and the only one I know of) to
+        % fix this.
+        varargout    = cell(1, nargout);
+        varargout{1} = this.readData(mem,ixToTarg,ixToRaw,selRange,selRangeSz,outSize);
+    end % of subsref
+
+    
+    function out = unsorted(this,ival)
+        % returns the unsorted data [NCol,NCha,#samples in acq. order]
+        if ~exist('ival','var')
+            mem = this.memPos;
+        else
+            mem = this.memPos(ival);
+        end
+        out = this.readData(mem);
+    end
+
+    
+    function out = readData(this,mem,cIxToTarg,cIxToRaw,selRange,selRangeSz,outSize)
+
+        if ~exist('outSize','var')
+            selRange{1} = ':';
+            selRange{2} = ':';
+            outSize = [this.dataSize(1:2),numel(mem)];
+            selRangeSz = outSize;
+            cIxToTarg = 1:selRangeSz(3);
+            cIxToRaw  = cIxToTarg;
+        else
+            if isequal( selRange{1}(:), (1:this.dataSize(1)).' )
+                selRange{1} = ':';
+            end
+            if isequal( selRange{2}(:), (1:this.dataSize(2)).' )
+                selRange{2} = ':';
+            end
+        end
+        out = complex(zeros(outSize,'single'));
+        out = reshape(out, selRangeSz(1), selRangeSz(2), []);
+
+        if isempty( mem )
+            out = reshape(out,outSize);
+            return
+        end
+
+        cIxToTarg = this.cast2MinimalUint( cIxToTarg );
+
+        % subsref overloading makes this.that-calls slow, so we need to
+        % avoid them whenever possible
+        szScanHeader = this.freadInfo.szScanHeader;
+        readSize     = this.freadInfo.sz;
+        readShape    = this.freadInfo.shape;
+        readCut      = this.freadInfo.cut;
+        keepOS       = [1:this.NCol/4, 1+this.NCol*3/4:this.NCol];
+        bRemoveOS    = this.arg.removeOS;
+        bIsReflected = this.IsReflected( cIxToRaw );
+        bRegrid      = this.flagRampSampRegrid && numel(this.rampSampTrj);
+        %SRY store information about raw data correction
+        bDoRawDataCorrect = this.arg.doRawDataCorrect;
+        bIsRawDataCorrect = this.IsRawDataCorrect( cIxToRaw );
+        isBrokenRead      = false;
+        if (bDoRawDataCorrect)
+            rawDataCorrect = this.arg.rawDataCorrectionFactors;
+        end
+
+        % MiVö: Raw data are read line-by-line in portions of 2xNColxNCha float32 points (2 for complex).
+        % Computing and sorting(!) on these small portions is quite expensive, esp. when
+        % it employs non-sequential memory paths. Examples are non-linear k-space acquisition
+        % or reflected lines.
+        % This can be sped up if slightly larger blocks of raw data are collected, first.
+        % Whenever a block is full, we do all those operations and save it in the final "out" array.
+        % What's a good block size? Depends on data size and machine (probably L2/L3/L4 cache sizes).
+        % So...? Start with a small block, measure the time-per-line and double block size until
+        % a minimum is found. Seems sufficiently robust to end up in a close-to-optimal size for every
+        % machine and data.
+        blockSz   = 2;          % size of blocks; must be 2^n; will be increased
+        doLockblockSz = false;  % whether blockSZ should be left untouched
+        tprev     = inf;        % previous time-per-line
+        blockCtr  = 0;
+        blockInit = -inf(readShape(1), readShape(2), blockSz, 'single'); %init with garbage
+        blockInit = complex( blockInit );
+        block     = blockInit;
+        
+        if bRegrid
+            v1       = single(1:selRangeSz(2));
+            v2       = single(1:blockSz);
+            rsTrj    = {this.rampSampTrj,v1,v2};
+            trgTrj   = linspace(min(this.rampSampTrj),max(this.rampSampTrj),this.NCol);
+            trgTrj   = {trgTrj,v1,v2};
+        end
+    
+        % counter for proper scaling of averages/segments
+        count_ave = zeros([1 1 size(out,3)],'single');
+        kMax      = numel( mem );   % max loop index
+
+        fid = this.fileopen();
+
+        for k = 1:kMax
+            % skip scan header
+            fseek(fid,mem(k) + szScanHeader,'bof');
+            raw = fread(fid, readSize, 'float=>single').';
+
+            % MiVö: With incomplete files fread() returns less than readSize points. The subsequent reshape will therefore error out.
+            %       We could check if numel(raw) == prod(readSize), but people recommend exception handling for performance
+            %       reasons. Do it.
+            try
+                raw = reshape( complex(raw(:,1), raw(:,2)), readShape);
+            catch exc
+                offset_bytes = mem(k) + szScanHeader;
+                %remainingSz = readSize(2) - size(raw,1);
+                warning( [mfilename() ':UnxpctdEOF'],  ...
+                          [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                            'Actual read size is [%s], desired size was: [%s]\n'                    ...
+                            'Will ignore this line and stop reading.\n'                             ...
+                            '=== MATLABs error message ================\n'                          ...
+                            exc.message                                                             ...
+                            '\n=== end of error =========================\n'                        ...
+                            ], offset_bytes, offset_bytes/1024^3, num2str(size(raw)), num2str(readSize.') )
+
+                % Reject this data fragment. To do so, init with the values of blockInit
+                clear raw
+                raw( 1:prod(readShape) ) = blockInit(1);
+                raw = reshape( raw, readShape );
+                isBrokenRead = true;   % remember it and bail out later
+            end
+
+            blockCtr = blockCtr + 1;
+            block(:,:,blockCtr) = raw;  % fast serial storage in a cache array
+            
+            % Do expensive computations and reorderings on the gathered block.
+            % Unfortunately, a lot of code is necessary, but that is executed much less
+            % frequent, so its worthwhile for speed.
+            % TODO: Do *everything* block-by-block
+            if blockCtr == blockSz || k == kMax || (isBrokenRead && blockCtr > 1)
+                s = tic;    % measure the time to process a block of data
+            
+                % remove MDH data from block:
+                block = block(readCut,:,:);
+
+                if bRegrid
+                    F     = griddedInterpolant(rsTrj,block);
+                    block = F(trgTrj);
+                end
+                
+                if sum(isnan(block(:)))>0
+                    keyboard
+                end
+
+                if bRemoveOS % remove oversampling in read
+                    block = ifft( block,[],1);
+                    block =  fft( block(keepOS,:,:),[],1);
+                end
+                                    
+                if ( bDoRawDataCorrect && bIsRawDataCorrect(k) )
+                    %SRY apply raw data correction if necessary
+                    block = bsxfun(@times, block, rawDataCorrect);
+                end
+                
+                ix = 1 + k - blockCtr : k;
+                if blockCtr ~= blockSz
+                    block = block(:,:,1:blockCtr);
+                end
+                
+                isRefl = bIsReflected(ix);
+                block(:,:,isRefl) = block(end:-1:1,:,isRefl);
+                
+                if ~isequal(selRange{1},':') || ~isequal(selRange{2},':')
+                    block = block( selRange{1}, selRange{2}, : );    % a bit slow
+                end
+                
+                [sortIdx, I] = sort( cIxToTarg(ix), 'ascend' );
+                block = block(:,:,I);     % reorder according to sorted target indices
+
+                % Mark duplicate indices with 1; we'll have to treat them special for proper averaging
+                % Bonus: The very first storage can be made much faster, because it's in-place.
+                %        Matlab urgently needs a "+=" operater, which makes "A(:,:,idx) = A(:,:,idx) + B"
+                %        in-place and more readable.
+                isDupe  = [ false, diff(sortIdx) == 0 ];
+
+                idx1 = sortIdx(~isDupe);     % acquired once in this block
+                idxN = sortIdx( isDupe);     % acquired multiple times
+
+                count_ave(idx1) = count_ave(idx1) + 1;
+
+                if isempty( idxN )
+                    % no duplicates
+                    if all( count_ave(idx1) == 1 )  % first acquisition of this line
+                        out(:,:,idx1) = block;                              % fast
+                    else
+                        out(:,:,idx1) = out(:,:,idx1) + block;              % slow
+                    end
+                else
+                    out(:,:,idx1) = out(:,:,idx1) + block(:,:,~isDupe);     % slower
+
+                    block = block(:,:,isDupe);
+                    for n = 1:numel(idxN)
+                        out(:,:,idxN(n)) = out(:,:,idxN(n)) + block(:,:,n); % snail :-)
+                        count_ave(idxN(n)) = count_ave(idxN(n)) + 1;
+                    end
+                end
+
+                % At the first few iterations, evaluate the spent time-per-line and decide
+                % what to do with the block size.
+                if ~doLockblockSz
+                    t = 1e6 * toc(s)/blockSz;   % micro seconds
+
+                    if t <= 1.1 * tprev % allow 10% inaccuracy. Usually bigger == better
+                        % New block size was faster. Go a step further.
+                        blockSz = blockSz * 2;
+                        blockInit = cat(3, blockInit, blockInit);
+                    else
+                        % regression; reset size and lock it
+                        blockSz = max( blockSz/2, 1 );
+                        blockInit = blockInit(:,:,1:blockSz);
+                        doLockblockSz = true;
+                    end
+                    if bRegrid
+                        rsTrj{3}  = single(1:blockSz);
+                        trgTrj{3} = rsTrj{3};
+                    end
+                    tprev = t;
+                end
+                    
+                blockCtr = 0;
+                block = blockInit;  % reset to garbage
+            end
+
+            if isBrokenRead
+                this.isBrokenFile = true;
+                break
+            end
+        end
+
+        fclose(fid);
+
+        % proper scaling (we don't want to sum our data but average it)
+        % For large "out" bsxfun(@rdivide,out,count_ave) is incredibly faster than
+        % bsxfun(@times,out,count_ave)!
+        % @rdivide is also running in parallel, while @times is not. :-/
+        if any( reshape(count_ave,[],1) > 1 )
+            clearvars -except  out  count_ave  outSize
+            count_ave = max( 1, count_ave );
+            out       = bsxfun( @rdivide, out, count_ave);
+        end
+
+        out = reshape(out,outSize);
+    end % of readData
+
+
+    function setDefaultFlags(this)
+        % method to set flags to default values
+        this.arg.removeOS            = false;
+        this.arg.rampSampRegrid      = false;
+        this.arg.doAverage           = false;
+        this.arg.averageReps         = false;
+        this.arg.averageSets         = false;
+        this.arg.ignoreSeg           = false;
+        this.arg.doRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        if ~isfield(this.arg,'rawDataCorrectionFactors')
+            this.arg.rawDataCorrectionFactors = [];
+        end
+    end
+
+    function dummy = resetFlags(this)
+        % method to reset flags to default values
+        this.flagRemoveOS            = false;
+        this.flagRampSampRegrid      = false;
+        this.flagDoRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        dummy = [];
+    end
+    
+    
+    function out = get.dataSize(this)
+        out = this.fullSize;
+        
+        if this.arg.removeOS
+            ix = ismember(this.dataDims, 'Col');
+            out(ix) = this.NCol/2;
+        end
+                
+        if this.flagAverageDim(1) || this.flagAverageDim(2)
+            warning('averaging in col and cha dim not supported, resetting flag');
+            this.flagAverageDim(1:2) = false;
+        end
+        
+        out(this.flagAverageDim) = 1;
+    end
+    
+    
+    function out = get.sqzSize(this)
+        % calculate sqzSize and sqzDims
+        out = this.dataSize(1);
+        this.sqzDims    = [];
+        this.sqzDims{1} = 'Col';
+        c = 1;
+        for k=2:numel(this.dataSize)
+            if this.dataSize(k)>1
+                c = c+1;
+                out(c) = this.dataSize(k);
+                this.sqzDims{c} = this.dataDims{k};
+            end
+        end
+    end
+    
+        
+    function set.flagRemoveOS(this,val)
+        % set method for removeOS
+        this.arg.removeOS = logical(val);
+    end
+    
+    function out = get.flagRemoveOS(this)
+        out = this.arg.removeOS;
+    end
+
+
+    function set.flagDoAverage(this,val)
+        ix = ismember(this.dataDims, 'Ave');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagDoAverage(this)
+        ix = ismember(this.dataDims, 'Ave');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagAverageReps(this,val)
+        ix = ismember(this.dataDims, 'Rep');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageReps(this)
+        ix = ismember(this.dataDims, 'Rep');
+        out = this.flagAverageDim(ix);
+    end
+
+
+    function set.flagAverageSets(this,val)
+        ix = ismember(this.dataDims, 'Set');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageSets(this)
+        ix = ismember(this.dataDims, 'Set');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagIgnoreSeg(this,val)
+        ix = ismember(this.dataDims, 'Seg');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagIgnoreSeg(this)
+        ix = ismember(this.dataDims, 'Seg');
+        out = this.flagAverageDim(ix);
+    end
+    
+    
+    function set.flagSkipToFirstLine(this,val)
+        val = logical(val);
+        if val ~= this.arg.skipToFirstLine
+            this.arg.skipToFirstLine = val;
+
+            if this.arg.skipToFirstLine
+                this.skipLin = min(this.Lin)-1;
+                this.skipPar = min(this.Par)-1;
+            else
+                this.skipLin = 0;
+                this.skipPar = 0;
+            end
+            NLinAlloc = max(1, this.NLin - this.skipLin);
+            NParAlloc = max(1, this.NPar - this.skipPar);
+            this.fullSize(3:4) = [NLinAlloc NParAlloc];
+        end
+    end
+
+
+    function out = get.flagSkipToFirstLine(this)
+        out = this.arg.skipToFirstLine;
+    end
+
+    function out = get.flagRampSampRegrid(this)
+        out = this.arg.rampSampRegrid;
+    end
+
+    function set.flagRampSampRegrid(this, val)
+        val = logical(val);
+        if (val == true && isempty(this.rampSampTrj))
+            error('No trajectory for regridding available');
+        end
+        this.arg.rampSampRegrid = val;
+    end
+
+    %SRY: accessor methods for raw data correction
+    function out = get.flagDoRawDataCorrect(this)
+        out = this.arg.doRawDataCorrect;
+    end
+
+    function set.flagDoRawDataCorrect(this, val)
+        val = logical(val);
+        if (val == true && strcmp(this.softwareVersion, 'vd'))
+            error('raw data correction for VD not supported/tested yet');
+        end
+
+        this.arg.doRawDataCorrect = val;
+    end
+
+    function out = get.RawDataCorrectionFactors(this)
+        out = this.arg.rawDataCorrectionFactors;
+    end
+
+    function set.RawDataCorrectionFactors(this, val)
+        %this may not work if trying to set the factors before NCha has
+        %a meaningful value (ie before calling clean)
+        if (~isrow(val) || length(val) ~= this.NCha)
+            error('RawDataCorrectionFactors must be a 1xNCha row vector');
+        end
+        this.arg.rawDataCorrectionFactors = val;
+    end
+
+end
+
+methods (Access='protected')
+    % helper functions
+
+    function fid = fileopen(this)
+        % look out for unlikely event that someone is switching between
+        % windows and unix systems:
+        [path,name,ext] = fileparts(this.filename);
+        this.filename   = fullfile(path,[name ext]);
+
+        % test access
+        if numel(dir(this.filename))==0
+            % update path when file of same name can be found in current
+            % working dir. -- otherwise throw error
+            [oldpath,name,ext] = fileparts(this.filename);
+            newloc = fullfile(pwd,[name ext]);
+            if numel(dir(newloc))==1
+                fprintf('Warning: File location updated from "%s" to current working directory.\n',oldpath);
+                this.filename = newloc;
+            else
+                error(['File "' this.filename '" not found.']);
+            end
+        end
+        fid = fopen(this.filename);
+    end
+
+    
+    function [selRange,selRangeSz,outSize] = calcRange(this,S)
+
+        switch S.type
+            case '()'
+                bSqueeze = false;
+            case '{}'
+                bSqueeze = true;
+        end
+
+        selRange = num2cell(ones(1,numel(this.dataSize)));
+        outSize  = ones(1,numel(this.dataSize));
+
+        if ( isempty(S.subs) || strcmpi(S.subs(1),'') )
+            % obj(): shortcut to select all data
+            % unfortunately, matlab does not allow the statement
+            % obj{}, so we can't use it...
+            % alternative: obj{''} (obj('') also works)
+            for k=1:numel(this.dataSize)
+                selRange{k}   = 1:this.dataSize(k);
+            end
+            if ~bSqueeze
+                outSize = this.dataSize;
+            else
+                outSize = this.sqzSize;
+            end
+        else
+            for k=1:numel(S.subs)
+                if ~bSqueeze
+                    cDim = k; % nothing to do
+                else
+                    % we need to rearrange selRange from squeezed
+                    % to original order
+                    cDim = find(strcmp(this.dataDims,this.sqzDims{k}) == 1);
+                end
+                if strcmp(S.subs{k},':')
+                    if k<numel(S.subs)
+                        selRange  {cDim} = 1:this.dataSize(cDim);
+                    else % all later dimensions selected and 'vectorized'!
+                        for l=cDim:numel(this.dataSize)
+                            selRange{l} = 1:this.dataSize(l);
+                        end
+                        outSize(k) = prod(double(this.dataSize(cDim:end)));
+                        break; % jump out ouf for-loop
+                    end
+                elseif isnumeric(S.subs{k})
+                    selRange{cDim} = single(S.subs{k});
+                else
+                    error('unknown string in brackets (e.g. 1:end does not work here)');
+                end
+                outSize(k) = numel(selRange{cDim});
+            end
+            for k=1:numel(selRange)
+                if max(selRange{k}) > this.dataSize(k)
+                    error('selection out of range');
+                end
+            end
+        end
+
+        selRangeSz = ones(1,numel(this.dataSize));
+        for k=1:numel(selRange)
+            selRangeSz(k) = numel(selRange{k});
+        end
+        
+        % now select all indices for the dims that are averaged
+        for k = find(this.flagAverageDim)
+            selRange{k} = 1:this.fullSize(k);
+        end
+    end
+
+    
+    function [ixToRaw, ixToTarget] = calcIndices(this)
+        % calculate indices to target & source(raw)
+        LinIx     = this.Lin - this.skipLin;
+        ParIx     = this.Par - this.skipPar;
+        ixToTarget = this.sub2ind_double(this.fullSize(3:end),...
+            LinIx, ParIx, this.Sli, this.Ave, this.Phs, this.Eco,...
+            this.Rep, this.Set, this.Seg, this.Ida, this.Idb,...
+            this.Idc, this.Idd, this.Ide);
+
+        % now calc. inverse index (page table: virtual to physical addresses)
+        % indices of lines that are not measured are zero
+        ixToRaw = zeros(1,prod(this.fullSize(3:end)),'double');
+
+        ixToRaw(ixToTarget) = 1:numel(ixToTarget);
+    end
+end
+
+methods (Static)
+    % helper functions, accessible from outside via <classname>.function()
+    % without an instance of the class.
+
+    function ndx = sub2ind_double(sz,varargin)
+        %SUB2IND_double Linear index from multiple subscripts.
+        %   Works like sub2ind but always returns double
+        %   also slightly faster, but no checks
+        %========================================
+        sz  = double(sz);
+        ndx = double(varargin{end}) - 1;
+        for i = length(sz)-1:-1:1
+            ix  = double(varargin{i});
+            ndx = sz(i)*ndx + ix-1;
+        end
+        ndx = ndx + 1;
+    end % sub2ind_double
+
+    function N = cast2MinimalUint( N )
+        Nmax = max( reshape(N,[],1) );
+        Nmin = min( reshape(N,[],1) );
+        if Nmin < 0 || Nmax > intmax('uint64')
+            return
+        end
+
+        if Nmax > intmax('uint32')
+            idxClass = 'uint64';
+        elseif Nmax > intmax('uint16')
+            idxClass = 'uint32';
+        else
+            idxClass = 'uint16';
+        end
+
+        N = cast( N, idxClass );
+    end % cast2MinimalUint()
+
+end % of methods (Static)
+
+end % classdef

--- a/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_JR.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_JR.m
@@ -1,0 +1,1130 @@
+classdef twix_map_obj_JR < matlab.mixin.Copyable %handle
+% class to hold information about raw data from siemens MRI scanners
+% (currently VB and VD software versions are supported and tested).
+%
+% Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de), Aug/19/2011
+%
+%
+% Modified by Wolf Blecher (wolf.blecher@tuebingen.mpg.de), Apr/26/2012
+% Added reorder index to indicate which lines are reflected
+% Added slice position for sorting, Mai/15/2012
+%
+% Order of many mdh parameters are now stored (including the reflected ADC
+% bit); PE, Jun/14/2012
+%
+% data is now 'memory mapped' and not read until demanded;
+% (see mapVBVD for a description) PE, Aug/02/2012
+%
+% twix_obj.image.unsorted now returns the data in its acq. order
+% [NCol,NCha,nsamples in acq. order], all average flags don't have an
+% influence on the output, but 'flagRemoveOS' still works, PE, Sep/04/13
+
+
+properties(Dependent=true)
+    %readerVersion
+    % flags
+    flagRemoveOS        % removes oversampling in read (col) during read operation
+    flagDoAverage       % averages over all avg during read operation
+    flagAverageReps     % averages over all repetitions
+    flagAverageSets     % averages over all sets
+    flagIgnoreSeg       % sum over all segments during read operation
+    flagSkipToFirstLine % skips lines/partitions up to the first
+                        % actually acquired line/partition
+                        % (e.g. only the center k-space is acquired in
+                        % refscans, we don't want all the leading zeros
+                        % in our data)
+                        % this is the default behaviour for everything
+                        % but image scans (but can be changed manually)
+    flagRampSampRegrid  % perform on-the-fly ramp sampling regridding
+    flagDoRawDataCorrect     %SRY: apply raw data correction factors during read operation
+    
+    RawDataCorrectionFactors %SRY: allow the user to set/get the factors
+end
+
+properties(GetAccess='public', SetAccess='public')
+    flagAverageDim      % new: flags that determines whether certain dim. should be averaged/ignored
+    filename
+    softwareVersion
+    dataType
+    rampSampTrj
+end
+
+properties(Dependent=true)
+    dataSize % this is the current output size, depends on fullSize + some flags
+    sqzSize
+    sqzDims
+end
+
+properties(GetAccess='public', SetAccess='protected')
+    dataDims
+
+    NCol  % mdh information
+    NCha  % mdh information
+    NLin  % mdh information
+    NPar  % mdh information
+    NSli  % mdh information
+    NAve  % mdh information
+    NPhs  % mdh information
+    NEco  % mdh information
+    NRep  % mdh information
+    NSet  % mdh information
+    NSeg  % mdh information
+    NIda  % mdh information
+    NIdb  % mdh information
+    NIdc  % mdh information
+    NIdd  % mdh information
+    NIde  % mdh information
+    NAcq  % simple counter
+
+    % mdh information
+    Lin
+    Par
+    Sli
+    Ave
+    Phs
+    Eco
+    Rep
+    Set
+    Seg
+    Ida
+    Idb
+    Idc
+    Idd
+    Ide
+
+    centerCol
+    centerLin
+    centerPar
+    cutOff
+    coilSelect
+    ROoffcenter
+    timeSinceRF
+    IsReflected
+    IsRawDataCorrect %SRY: storage for MDH flag raw data correct
+
+    slicePos
+    freeParam
+    iceParam
+    scancounter
+    timestamp
+    pmutime
+
+    % memory position in file
+    memPos
+    
+    isBrokenFile % errors when parsing? 
+end
+
+properties(Hidden=true, SetAccess='protected')
+    arg  % arguments
+
+    fullSize % this is the full size of the data set according to the mdhs, i.e. flags
+             % like 'reduceOS' have no influence on it
+
+    freadInfo
+
+    skipLin
+    skipPar
+end
+
+methods
+    % Constructor:
+    function this = twix_map_obj(arg,dataType,fname,version,rstraj)
+
+        if ~exist('dataType','var')
+            this.dataType = 'image';
+        else
+            this.dataType = lower(dataType);
+        end
+
+        this.filename         = fname;
+        this.softwareVersion  = version;
+
+        this.IsReflected      = logical([]);
+        this.IsRawDataCorrect = logical([]); %SRY
+        this.NAcq             = 0;
+        this.isBrokenFile     = false;
+
+        this.dataDims = {'Col','Cha','Lin','Par','Sli','Ave','Phs',...
+            'Eco','Rep','Set','Seg','Ida','Idb','Idc','Idd','Ide'};
+            
+        this.setDefaultFlags();
+        if exist('arg','var')
+            % copy relevant arguments from mapVBVD argument list
+            names=fieldnames(arg);
+            for k=1:numel(names)
+                if isfield(this.arg,names{k})
+                    this.arg.(names{k}) = arg.(names{k});
+                end
+            end
+        end
+
+        this.flagAverageDim(ismember(this.dataDims,'Ave')) = this.arg.doAverage;
+        this.flagAverageDim(ismember(this.dataDims,'Rep')) = this.arg.averageReps;
+        this.flagAverageDim(ismember(this.dataDims,'Set')) = this.arg.averageSets;
+        this.flagAverageDim(ismember(this.dataDims,'Seg')) = this.arg.ignoreSeg;
+        
+        switch this.softwareVersion
+            case 'vb'
+                % every channel has its own full mdh
+                this.freadInfo.szScanHeader    =   0; % [bytes]
+                this.freadInfo.szChannelHeader = 128; % [bytes]
+                this.freadInfo.iceParamSz      =   4;
+            case 'vd'
+                if ( this.arg.doRawDataCorrect )
+                    error('raw data correction for VD not supported/tested yet');
+                end
+                this.freadInfo.szScanHeader    = 192; % [bytes]
+                this.freadInfo.szChannelHeader =  32; % [bytes]
+                this.freadInfo.iceParamSz      =  24; % vd version supports up to 24 ice params
+            otherwise
+                error('software version not supported');
+        end
+
+        if exist('rstraj','var')
+            this.rampSampTrj = rstraj;
+        else
+            this.rampSampTrj        = [];
+            this.arg.rampSampRegrid = false;
+        end
+    end
+
+    
+    % Copy function - replacement for matlab.mixin.Copyable.copy() to create object copies
+    % from http://undocumentedmatlab.com/blog/general-use-object-copy
+    function newObj = copy(this)
+        isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+        if isOctave || verLessThan('matlab','7.11')
+            % R2010a or earlier - serialize via temp file (slower)
+            fname = [tempname '.mat'];
+            save(fname, 'obj');
+            newObj = load(fname);
+            newObj = newObj.obj;
+            delete(fname);
+        else
+            % R2010b or newer - directly in memory (faster)
+            objByteArray = getByteStreamFromArray(this);
+            newObj = getArrayFromByteStream(objByteArray);
+        end
+    end
+
+    
+    function this = readMDH(this, mdh, filePos )
+        % extract all values in all MDHs at once
+        %
+        % data types:
+        % Use double for everything non-logical, both ints and floats. Seems the
+        % most robust way to avoid unexpected cast-issues with very nasty side effects.
+        % Examples: eps(single(16777216)) == 2
+        %           uint32( 10 ) - uint32( 20 ) == 0
+        %           uint16(100) + 1e5 == 65535
+        %           size(1 : 10000 * uint16(1000)) ==  [1  65535]
+        %
+        % The 1st example always hits the timestamps.
+
+        if ~isstruct( mdh ) || isempty( mdh )
+            return
+        end
+
+        this.NAcq     = numel( filePos );
+        sLC           = double( mdh.sLC ) + 1;  % +1: convert to matlab index style
+        evalInfoMask1 = double( mdh.aulEvalInfoMask(:,1) ).';
+
+        % save mdh information for each line
+        this.NCol       = double( mdh.ushSamplesInScan ).';
+        this.NCha       = double( mdh.ushUsedChannels ).';
+        this.Lin        = sLC(:,1).' ;
+        this.Ave        = sLC(:,2).' ;
+        this.Sli        = sLC(:,3).' ;
+        this.Par        = sLC(:,4).' ;
+        this.Eco        = sLC(:,5).' ;
+        this.Phs        = sLC(:,6).' ;
+        this.Rep        = sLC(:,7).' ;
+        this.Set        = sLC(:,8).' ;
+        this.Seg        = sLC(:,9).' ;
+        this.Ida        = sLC(:,10).';
+        this.Idb        = sLC(:,11).';
+        this.Idc        = sLC(:,12).';
+        this.Idd        = sLC(:,13).';
+        this.Ide        = sLC(:,14).';
+
+        this.centerCol   = double( mdh.ushKSpaceCentreColumn ).' + 1;
+        this.centerLin   = double( mdh.ushKSpaceCentreLineNo ).' + 1;
+        this.centerPar   = double( mdh.ushKSpaceCentrePartitionNo ).' + 1;
+        this.cutOff      = double( mdh.sCutOff ).';
+        this.coilSelect  = double( mdh.ushCoilSelect ).';
+        this.ROoffcenter = double( mdh.fReadOutOffcentre ).';
+        this.timeSinceRF = double( mdh.ulTimeSinceLastRF ).';
+        this.IsReflected = logical(min(bitand(evalInfoMask1,2^24),1));
+        this.scancounter = double( mdh.ulScanCounter ).';
+        this.timestamp   = double( mdh.ulTimeStamp ).';
+        this.pmutime     = double( mdh.ulPMUTimeStamp ).';
+        this.IsRawDataCorrect = logical(min(bitand(evalInfoMask1,2^10),1)); %SRY
+        this.slicePos    = double( mdh.SlicePos ).';
+        this.iceParam    = double( mdh.aushIceProgramPara ).';
+        this.freeParam   = double( mdh.aushFreePara ).';
+
+        this.memPos = filePos;
+
+    end % of readMDH
+
+    function this = tryAndFixLastMdh(this)
+        eofWarning = [mfilename() ':UnxpctdEOF'];   % We have it inside this.readData()
+        warning( 'off', eofWarning )    % silence warnings for read...
+        warning( 'off', 'foo:bar'  )    % ... and a stupid placeholder
+
+        isLastAcqGood = false;
+        cnt = 0;
+
+        while ~isLastAcqGood  &&  this.NAcq > 0  && cnt < 100
+            warning( 'foo:bar', 'baz') % make sure that lastwarn() does not return eofWarning
+            try
+                this.clean();
+                this.unsorted(this.NAcq);
+                [~, warnid] = lastwarn();
+                if strcmp( warnid, eofWarning )
+                    error( 'Make sure to go to the catch block.')
+                end
+                isLastAcqGood = true;
+            catch
+                this.isBrokenFile = true;
+                this.NAcq = this.NAcq-1;
+            end
+            cnt = cnt + 1;
+        end
+        
+%         if this.NAcq == 0  ||  cnt > 99    % everything is garbage
+%             warning(  )
+%         end
+
+        warning( 'on', eofWarning )
+    end
+
+    function this = clean(this)
+        
+        if this.NAcq == 0
+            return;
+        end
+
+        % Cut mdh data to actual size. Maybe we rejected acquisitions at the end
+        % due to read errors.
+        fields = { 'NCol', 'NCha',                                                  ...
+                   'Lin', 'Par', 'Sli', 'Ave', 'Phs', 'Eco', 'Rep',                 ...
+                   'Set', 'Seg', 'Ida', 'Idb', 'Idc', 'Idd', 'Ide',                 ...
+                   'centerCol'  ,   'centerLin',   'centerPar',           'cutOff', ...
+                   'coilSelect' , 'ROoffcenter', 'timeSinceRF',      'IsReflected', ...
+                   'scancounter',   'timestamp',     'pmutime', 'IsRawDataCorrect', ...
+                   'slicePos'   ,    'iceParam',   'freeParam',           'memPos'  };
+        
+        nack = this.NAcq;
+        idx = 1:nack;
+
+        for f = fields
+            f1 = f{1};
+            if size(this.(f1),2) > nack   % rarely
+                this.(f1) = this.(f1)(:,idx);       % 1st dim: samples,  2nd dim acquisitions
+            end
+        end
+
+        this.NLin = max(this.Lin);
+        this.NPar = max(this.Par);
+        this.NSli = max(this.Sli);
+        this.NAve = max(this.Ave);
+        this.NPhs = max(this.Phs);
+        this.NEco = max(this.Eco);
+        this.NRep = max(this.Rep);
+        this.NSet = max(this.Set);
+        this.NSeg = max(this.Seg);
+        this.NIda = max(this.Ida);
+        this.NIdb = max(this.Idb);
+        this.NIdc = max(this.Idc);
+        this.NIdd = max(this.Idd);
+        this.NIde = max(this.Ide);
+
+        % ok, let us assume for now that all NCol and NCha entries are
+        % the same for all mdhs:
+        this.NCol = this.NCol(1);
+        this.NCha = this.NCha(1);
+
+        if strcmp(this.dataType,'refscan')
+            %pehses: check for lines with 'negative' line/partition numbers
+            %this can happen when the reference scan line/partition range
+            %exceeds the one of the actual imaging scan
+            if this.NLin>65500  %uint overflow check
+                this.Lin  = mod(this.Lin + (65536 - min(this.Lin(this.Lin>65500))),65536)+1;
+                this.NLin = max(this.Lin);
+            end
+            if this.NPar>65500  %uint overflow check
+                this.Par  = mod(this.Par + (65536 - min(this.Par(this.Par>65500))),65536)+1;
+                this.NPar = max(this.Par);
+            end
+        end
+
+        % to reduce the matrix sizes of non-image scans, the size
+        % of the refscan_obj()-matrix is reduced to the area of the
+        % actually scanned acs lines (the outer part of k-space
+        % that is not scanned is not filled with zeros)
+        % this behaviour is controlled by flagSkipToFirstLine which is
+        % set to true by default for everything but image scans
+        if ~this.flagSkipToFirstLine
+            % the output matrix should include all leading zeros
+            this.skipLin = 0;
+            this.skipPar = 0;
+        else
+            % otherwise, cut the matrix size to the start of the
+            % first actually scanned line/partition (e.g. the acs/
+            % phasecor data is only acquired in the k-space center)
+            this.skipLin = min(this.Lin)-1;
+            this.skipPar = min(this.Par)-1;
+        end
+        NLinAlloc = max(1, this.NLin - this.skipLin);
+        NParAlloc = max(1, this.NPar - this.skipPar);
+
+        this.fullSize = [ this.NCol this.NCha NLinAlloc NParAlloc...
+                          this.NSli this.NAve this.NPhs this.NEco...
+                          this.NRep this.NSet this.NSeg this.NIda...
+                          this.NIdb this.NIdc this.NIdd this.NIde ];
+
+        nByte = this.NCha*(this.freadInfo.szChannelHeader+8*this.NCol);
+
+        % size for fread
+        this.freadInfo.sz    = [2 nByte/8];
+        % reshape size
+        this.freadInfo.shape = [this.NCol+this.freadInfo.szChannelHeader/8 ...
+                               , this.NCha];
+        % we need to cut MDHs from fread data
+        this.freadInfo.cut   = this.freadInfo.szChannelHeader/8 + (1 : this.NCol);
+
+    end % of clean
+
+
+    function varargout = subsref(this, S)
+        % this is where the magic happens
+        % Now seriously. Overloading of the subsref-method and working
+        % with a gazillion indices got really messy really fast. At
+        % some point, I should probably clean this code up a bit. But
+        % good news everyone: It seems to work.
+        switch S(1).type
+            case '.'
+                % We don't want to manage method/variable calls, so we'll
+                % simply call the built-in subsref-function in this case.
+                if nargout == 0
+                    varargout{1} = builtin('subsref', this, S); % CTR fix.
+                else
+                    varargout      = cell(1, nargout);
+                    [varargout{:}] = builtin('subsref', this, S);
+                end
+                return;
+            case {'()','{}'}
+            otherwise
+                error('operator not supported');
+        end
+
+        [selRange,selRangeSz,outSize] = this.calcRange(S(1));
+
+    	% calculate page table (virtual to physical addresses)
+        % this is now done every time, i.e. result is no longer saved in
+        % a property - slower but safer (and easier to keep track of updates)
+        ixToRaw = this.calcIndices;
+        
+        tmp = reshape(1:prod(double(this.fullSize(3:end))), this.fullSize(3:end));
+        tmp = tmp(selRange{3:end});
+        ixToRaw = ixToRaw(tmp); clear tmp;
+        ixToRaw = ixToRaw(:);
+        % delete all entries that point to zero (the "NULL"-pointer)
+        notAcquired = (ixToRaw == 0);
+        ixToRaw (notAcquired) = []; clear notAcquired;
+
+        % calculate ixToTarg for possibly smaller, shifted + segmented
+        % target matrix:
+        cIx = ones(14, numel(ixToRaw), 'single');
+        if ~this.flagAverageDim(3)
+            cIx( 1,:) = this.Lin(ixToRaw) - this.skipLin;
+        end
+        if ~this.flagAverageDim(4)
+            cIx( 2,:) = this.Par(ixToRaw) - this.skipPar;
+        end
+        if ~this.flagAverageDim(5)
+            cIx( 3,:) = this.Sli(ixToRaw);
+        end
+        if ~this.flagAverageDim(6)
+            cIx( 4,:) = this.Ave(ixToRaw);
+        end
+        if ~this.flagAverageDim(7)
+            cIx( 5,:) = this.Phs(ixToRaw);
+        end
+        if ~this.flagAverageDim(8)
+            cIx( 6,:) = this.Eco(ixToRaw);
+        end
+        if ~this.flagAverageDim(9)
+            cIx( 7,:) = this.Rep(ixToRaw);
+        end
+        if ~this.flagAverageDim(10)
+            cIx( 8,:) = this.Set(ixToRaw);
+        end
+        if ~this.flagAverageDim(11)
+            cIx( 9,:) = this.Seg(ixToRaw);
+        end
+        if ~this.flagAverageDim(12)
+            cIx(10,:) = this.Ida(ixToRaw);
+        end
+        if ~this.flagAverageDim(13)
+            cIx(11,:) = this.Idb(ixToRaw);
+        end
+        if ~this.flagAverageDim(14)
+            cIx(12,:) = this.Idc(ixToRaw);
+        end
+        if ~this.flagAverageDim(15)
+            cIx(13,:) = this.Idd(ixToRaw);
+        end
+        if ~this.flagAverageDim(16)
+            cIx(14,:) = this.Ide(ixToRaw);
+        end
+
+        % make sure that indices fit inside selection range
+        for k=3:numel(selRange)
+            tmp = cIx(k-2,:);
+            for l=1:numel(selRange{k})
+                cIx(k-2,tmp==selRange{k}(l)) = l;
+            end
+        end
+
+        sz = selRangeSz(3:end); % extra variable needed for octave compatibility
+        ixToTarg = this.sub2ind_double(sz, cIx(1,:),cIx(2,:),cIx(3,:),...
+            cIx(4,:),cIx(5,:),cIx(6,:),cIx(7,:),cIx(8,:),cIx(9,:),...
+            cIx(10,:),cIx(11,:),cIx(12,:),cIx(13,:),cIx(14,:));
+        
+        mem = this.memPos(ixToRaw);
+        % sort mem for quicker access, sort cIxToTarg/Raw accordingly
+        [mem,ix]  = sort(mem);
+        ixToTarg = ixToTarg(ix);
+        ixToRaw  = ixToRaw(ix);
+        clear ix;
+
+        % For a call of type data{:,:,1:3} matlab expects more than one
+        % output variable (three in this case) and will throw an error
+        % otherwise. This is a lazy way (and the only one I know of) to
+        % fix this.
+        varargout    = cell(1, nargout);
+        varargout{1} = this.readData(mem,ixToTarg,ixToRaw,selRange,selRangeSz,outSize);
+    end % of subsref
+
+    
+    function out = unsorted(this,ival)
+        % returns the unsorted data [NCol,NCha,#samples in acq. order]
+        if ~exist('ival','var')
+            mem = this.memPos;
+        else
+            mem = this.memPos(ival);
+        end
+        out = this.readData(mem);
+    end
+
+    
+    function out = readData(this,mem,cIxToTarg,cIxToRaw,selRange,selRangeSz,outSize)
+
+        if ~exist('outSize','var')
+            selRange{1} = ':';
+            selRange{2} = ':';
+            outSize = [this.dataSize(1:2),numel(mem)];
+            selRangeSz = outSize;
+            cIxToTarg = 1:selRangeSz(3);
+            cIxToRaw  = cIxToTarg;
+        else
+            if isequal( selRange{1}(:), (1:this.dataSize(1)).' )
+                selRange{1} = ':';
+            end
+            if isequal( selRange{2}(:), (1:this.dataSize(2)).' )
+                selRange{2} = ':';
+            end
+        end
+        out = complex(zeros(outSize,'single'));
+        out = reshape(out, selRangeSz(1), selRangeSz(2), []);
+
+        if isempty( mem )
+            out = reshape(out,outSize);
+            return
+        end
+
+        cIxToTarg = this.cast2MinimalUint( cIxToTarg );
+
+        % subsref overloading makes this.that-calls slow, so we need to
+        % avoid them whenever possible
+        szScanHeader = this.freadInfo.szScanHeader;
+        readSize     = this.freadInfo.sz;
+        readShape    = this.freadInfo.shape;
+        readCut      = this.freadInfo.cut;
+        keepOS       = [1:this.NCol/4, 1+this.NCol*3/4:this.NCol];
+        bRemoveOS    = this.arg.removeOS;
+        bIsReflected = this.IsReflected(cIxToRaw);
+        bRegrid      = this.flagRampSampRegrid && numel(this.rampSampTrj);
+        slicedata    = this.slicePos(:, cIxToRaw);
+        %SRY store information about raw data correction
+        bDoRawDataCorrect = this.arg.doRawDataCorrect;
+        bIsRawDataCorrect = this.IsRawDataCorrect( cIxToRaw );
+        isBrokenRead      = false;
+        if (bDoRawDataCorrect)
+            rawDataCorrect = this.arg.rawDataCorrectionFactors;
+        end
+
+        % MiVö: Raw data are read line-by-line in portions of 2xNColxNCha float32 points (2 for complex).
+        % Computing and sorting(!) on these small portions is quite expensive, esp. when
+        % it employs non-sequential memory paths. Examples are non-linear k-space acquisition
+        % or reflected lines.
+        % This can be sped up if slightly larger blocks of raw data are collected, first.
+        % Whenever a block is full, we do all those operations and save it in the final "out" array.
+        % What's a good block size? Depends on data size and machine (probably L2/L3/L4 cache sizes).
+        % So...? Start with a small block, measure the time-per-line and double block size until
+        % a minimum is found. Seems sufficiently robust to end up in a close-to-optimal size for every
+        % machine and data.
+        blockSz   = 2;          % size of blocks; must be 2^n; will be increased
+        doLockblockSz = false;  % whether blockSZ should be left untouched
+        tprev     = inf;        % previous time-per-line
+        blockCtr  = 0;
+        blockInit = -inf(readShape(1), readShape(2), blockSz, 'single'); %init with garbage
+        blockInit = complex( blockInit );
+        block     = blockInit;
+        
+        if bRegrid
+            v1       = single(1:selRangeSz(2));
+            v2       = single(1:blockSz);
+            rsTrj    = {this.rampSampTrj,v1,v2};
+            trgTrj   = linspace(min(this.rampSampTrj),max(this.rampSampTrj),this.NCol);
+            trgTrj   = {trgTrj,v1,v2};
+        end
+    
+        % counter for proper scaling of averages/segments
+        count_ave = zeros([1 1 size(out,3)],'single');
+        kMax      = numel( mem );   % max loop index
+
+        fid = this.fileopen();
+
+        for k = 1:kMax
+            % skip scan header
+            fseek(fid,mem(k) + szScanHeader,'bof');
+            raw = fread(fid, readSize, 'float=>single').';
+
+            % MiVö: With incomplete files fread() returns less than readSize points. The subsequent reshape will therefore error out.
+            %       We could check if numel(raw) == prod(readSize), but people recommend exception handling for performance
+            %       reasons. Do it.
+            try
+                raw = reshape( complex(raw(:,1), raw(:,2)), readShape);
+            catch exc
+                offset_bytes = mem(k) + szScanHeader;
+                %remainingSz = readSize(2) - size(raw,1);
+                warning( [mfilename() ':UnxpctdEOF'],  ...
+                          [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                            'Actual read size is [%s], desired size was: [%s]\n'                    ...
+                            'Will ignore this line and stop reading.\n'                             ...
+                            '=== MATLABs error message ================\n'                          ...
+                            exc.message                                                             ...
+                            '\n=== end of error =========================\n'                        ...
+                            ], offset_bytes, offset_bytes/1024^3, num2str(size(raw)), num2str(readSize.') )
+
+                % Reject this data fragment. To do so, init with the values of blockInit
+                clear raw
+                raw( 1:prod(readShape) ) = blockInit(1);
+                raw = reshape( raw, readShape );
+                isBrokenRead = true;   % remember it and bail out later
+            end
+
+            blockCtr = blockCtr + 1;
+            block(:,:,blockCtr) = raw;  % fast serial storage in a cache array
+
+            % Do expensive computations and reorderings on the gathered block.
+            % Unfortunately, a lot of code is necessary, but that is executed much less
+            % frequent, so its worthwhile for speed.
+            % TODO: Do *everything* block-by-block
+            if blockCtr == blockSz || k == kMax || (isBrokenRead && blockCtr > 1)
+                s = tic;    % measure the time to process a block of data
+                
+                % remove MDH data from block:
+                block = block(readCut,:,:);
+                
+                if bRegrid
+                    % correct for readout shifts
+                    % the nco frequency is always scaled to the max.
+                    % gradient amp and does account for ramp-sampling
+                    ro_shift = this.calcOffcenterShiftRO(slicedata(:,k));
+                    deltak = max(abs(diff(rsTrj{1})));
+                    phase = (0:this.NCol-1).' * deltak * ro_shift;
+                    phase_factor = exp(1j*2*pi*(phase - ro_shift * rsTrj{1}));
+                    block = bsxfun(@times, block, phase_factor);
+
+                    % grid the data
+                    F = griddedInterpolant(rsTrj, block);
+                    block = F(trgTrj);
+                end
+                
+                ix = 1 + k - blockCtr : k;
+                if blockCtr ~= blockSz
+                    block = block(:,:,1:blockCtr);
+                end
+                
+                if sum(isnan(block(:)))>0
+                    keyboard
+                end
+
+                if bRemoveOS % remove oversampling in read
+                    block = ifft(block, [], 1);
+                    block =  fft(block(keepOS,:,:), [], 1);
+                end
+                                    
+                if ( bDoRawDataCorrect && bIsRawDataCorrect(k) )
+                    %SRY apply raw data correction if necessary
+                    block = bsxfun(@times, block, rawDataCorrect);
+                end
+                
+                isRefl = bIsReflected(ix);
+                block(:,:,isRefl) = block(end:-1:1,:,isRefl);
+                
+                if ~isequal(selRange{1},':') || ~isequal(selRange{2},':')
+                    block = block( selRange{1}, selRange{2}, : );    % a bit slow
+                end
+                
+                [sortIdx, I] = sort( cIxToTarg(ix), 'ascend' );
+                block = block(:,:,I);     % reorder according to sorted target indices
+
+                % Mark duplicate indices with 1; we'll have to treat them special for proper averaging
+                % Bonus: The very first storage can be made much faster, because it's in-place.
+                %        Matlab urgently needs a "+=" operater, which makes "A(:,:,idx) = A(:,:,idx) + B"
+                %        in-place and more readable.
+                isDupe  = [ false, diff(sortIdx) == 0 ];
+
+                idx1 = sortIdx(~isDupe);     % acquired once in this block
+                idxN = sortIdx( isDupe);     % acquired multiple times
+
+                count_ave(idx1) = count_ave(idx1) + 1;
+
+                if isempty( idxN )
+                    % no duplicates
+                    if all( count_ave(idx1) == 1 )  % first acquisition of this line
+                        out(:,:,idx1) = block;                              % fast
+                    else
+                        out(:,:,idx1) = out(:,:,idx1) + block;              % slow
+                    end
+                else
+                    out(:,:,idx1) = out(:,:,idx1) + block(:,:,~isDupe);     % slower
+
+                    block = block(:,:,isDupe);
+                    for n = 1:numel(idxN)
+                        out(:,:,idxN(n)) = out(:,:,idxN(n)) + block(:,:,n); % snail :-)
+                        count_ave(idxN(n)) = count_ave(idxN(n)) + 1;
+                    end
+                end
+
+                % At the first few iterations, evaluate the spent time-per-line and decide
+                % what to do with the block size.
+                if ~doLockblockSz
+                    t = 1e6 * toc(s)/blockSz;   % micro seconds
+
+                    if t <= 1.1 * tprev % allow 10% inaccuracy. Usually bigger == better
+                        % New block size was faster. Go a step further.
+                        blockSz = blockSz * 2;
+                        blockInit = cat(3, blockInit, blockInit);
+                    else
+                        % regression; reset size and lock it
+                        blockSz = max( blockSz/2, 1 );
+                        blockInit = blockInit(:,:,1:blockSz);
+                        doLockblockSz = true;
+                    end
+                    if bRegrid
+                        rsTrj{3}  = single(1:blockSz);
+                        trgTrj{3} = rsTrj{3};
+                    end
+                    tprev = t;
+                end
+                    
+                blockCtr = 0;
+                block = blockInit;  % reset to garbage
+            end
+
+            if isBrokenRead
+                this.isBrokenFile = true;
+                break
+            end
+        end
+
+        fclose(fid);
+
+        % proper scaling (we don't want to sum our data but average it)
+        % For large "out" bsxfun(@rdivide,out,count_ave) is incredibly faster than
+        % bsxfun(@times,out,count_ave)!
+        % @rdivide is also running in parallel, while @times is not. :-/
+        if any( reshape(count_ave,[],1) > 1 )
+            clearvars -except  out  count_ave  outSize
+            count_ave = max( 1, count_ave );
+            out       = bsxfun( @rdivide, out, count_ave);
+        end
+
+        out = reshape(out,outSize);
+    end % of readData
+
+
+    function setDefaultFlags(this)
+        % method to set flags to default values
+        this.arg.removeOS            = false;
+        this.arg.rampSampRegrid      = false;
+        this.arg.doAverage           = false;
+        this.arg.averageReps         = false;
+        this.arg.averageSets         = false;
+        this.arg.ignoreSeg           = false;
+        this.arg.doRawDataCorrect    = false;
+        this.flagAverageDim          = false(1, 16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        if ~isfield(this.arg,'rawDataCorrectionFactors')
+            this.arg.rawDataCorrectionFactors = [];
+        end
+    end
+
+    function dummy = resetFlags(this)
+        % method to reset flags to default values
+        this.flagRemoveOS            = false;
+        this.flagRampSampRegrid      = false;
+        this.flagDoRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        dummy = [];
+    end
+    
+    
+    function versiontime = get.readerVersion(~)
+        % returns utc-unixtime of last commit (from file precommit-unixtime)
+        p = fileparts(mfilename('fullpath'));
+        fid = fopen(fullfile(p, 'precommit_unixtime'));
+        versiontime = uint64(str2double(fgetl(fid)));
+        fclose(fid);
+    end
+    
+    function out = get.dataSize(this)
+        out = this.fullSize;
+        
+        if this.arg.removeOS
+            ix = ismember(this.dataDims, 'Col');
+            out(ix) = this.NCol/2;
+        end
+                
+        if this.flagAverageDim(1) || this.flagAverageDim(2)
+            warning('averaging in col and cha dim not supported, resetting flag');
+            this.flagAverageDim(1:2) = false;
+        end
+        
+        out(this.flagAverageDim) = 1;
+    end
+    
+    
+    function out = get.sqzDims(this)
+        out = this.dataDims(this.dataSize>1);
+    end
+    
+    
+    function out = get.sqzSize(this)
+        out = this.dataSize(this.dataSize>1);
+    end
+    
+        
+    function set.flagRemoveOS(this,val)
+        % set method for removeOS
+        this.arg.removeOS = logical(val);
+    end
+    
+    function out = get.flagRemoveOS(this)
+        out = this.arg.removeOS;
+    end
+
+
+    function set.flagDoAverage(this,val)
+        ix = ismember(this.dataDims, 'Ave');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagDoAverage(this)
+        ix = ismember(this.dataDims, 'Ave');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagAverageReps(this,val)
+        ix = ismember(this.dataDims, 'Rep');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageReps(this)
+        ix = ismember(this.dataDims, 'Rep');
+        out = this.flagAverageDim(ix);
+    end
+
+
+    function set.flagAverageSets(this,val)
+        ix = ismember(this.dataDims, 'Set');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageSets(this)
+        ix = ismember(this.dataDims, 'Set');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagIgnoreSeg(this,val)
+        ix = ismember(this.dataDims, 'Seg');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagIgnoreSeg(this)
+        ix = ismember(this.dataDims, 'Seg');
+        out = this.flagAverageDim(ix);
+    end
+    
+    
+    function set.flagSkipToFirstLine(this,val)
+        val = logical(val);
+        if val ~= this.arg.skipToFirstLine
+            this.arg.skipToFirstLine = val;
+
+            if this.arg.skipToFirstLine
+                this.skipLin = min(this.Lin)-1;
+                this.skipPar = min(this.Par)-1;
+            else
+                this.skipLin = 0;
+                this.skipPar = 0;
+            end
+            NLinAlloc = max(1, this.NLin - this.skipLin);
+            NParAlloc = max(1, this.NPar - this.skipPar);
+            this.fullSize(3:4) = [NLinAlloc NParAlloc];
+        end
+    end
+
+
+    function out = get.flagSkipToFirstLine(this)
+        out = this.arg.skipToFirstLine;
+    end
+
+    function out = get.flagRampSampRegrid(this)
+        out = this.arg.rampSampRegrid;
+    end
+
+    function set.flagRampSampRegrid(this, val)
+        val = logical(val);
+        if (val == true && isempty(this.rampSampTrj))
+            error('No trajectory for regridding available');
+        end
+        this.arg.rampSampRegrid = val;
+    end
+
+    %SRY: accessor methods for raw data correction
+    function out = get.flagDoRawDataCorrect(this)
+        out = this.arg.doRawDataCorrect;
+    end
+
+    function set.flagDoRawDataCorrect(this, val)
+        val = logical(val);
+        if (val == true && strcmp(this.softwareVersion, 'vd'))
+            error('raw data correction for VD not supported/tested yet');
+        end
+
+        this.arg.doRawDataCorrect = val;
+    end
+
+    function out = get.RawDataCorrectionFactors(this)
+        out = this.arg.rawDataCorrectionFactors;
+    end
+
+    function set.RawDataCorrectionFactors(this, val)
+        %this may not work if trying to set the factors before NCha has
+        %a meaningful value (ie before calling clean)
+        if (~isrow(val) || length(val) ~= this.NCha)
+            error('RawDataCorrectionFactors must be a 1xNCha row vector');
+        end
+        this.arg.rawDataCorrectionFactors = val;
+    end
+
+end
+
+methods (Access='protected')
+    % helper functions
+    
+    function fid = fileopen(this)
+        % look out for unlikely event that someone is switching between
+        % windows and unix systems:
+        [path,name,ext] = fileparts(this.filename);
+        this.filename   = fullfile(path,[name ext]);
+
+        % test access
+        if numel(dir(this.filename))==0
+            % update path when file of same name can be found in current
+            % working dir. -- otherwise throw error
+            [oldpath,name,ext] = fileparts(this.filename);
+            newloc = fullfile(pwd,[name ext]);
+            if numel(dir(newloc))==1
+                fprintf('Warning: File location updated from "%s" to current working directory.\n',oldpath);
+                this.filename = newloc;
+            else
+                error(['File "' this.filename '" not found.']);
+            end
+        end
+        fid = fopen(this.filename);
+    end
+
+    
+    function [selRange,selRangeSz,outSize] = calcRange(this,S)
+
+        switch S.type
+            case '()'
+                bSqueeze = false;
+            case '{}'
+                bSqueeze = true;
+        end
+
+        selRange = num2cell(ones(1,numel(this.dataSize)));
+        outSize  = ones(1,numel(this.dataSize));
+
+        if ( isempty(S.subs) || strcmpi(S.subs(1),'') )
+            % obj(): shortcut to select all data
+            % unfortunately, matlab does not allow the statement
+            % obj{}, so we can't use it...
+            % alternative: obj{''} (obj('') also works)
+            for k=1:numel(this.dataSize)
+                selRange{k}   = 1:this.dataSize(k);
+            end
+            if ~bSqueeze
+                outSize = this.dataSize;
+            else
+                outSize = this.sqzSize;
+            end
+        else
+            for k=1:numel(S.subs)
+                if ~bSqueeze
+                    cDim = k; % nothing to do
+                else
+                    % we need to rearrange selRange from squeezed
+                    % to original order
+                    cDim = find(strcmp(this.dataDims,this.sqzDims{k}) == 1);
+                end
+                if strcmp(S.subs{k},':')
+                    if k<numel(S.subs)
+                        selRange  {cDim} = 1:this.dataSize(cDim);
+                    else % all later dimensions selected and 'vectorized'!
+                        for l=cDim:numel(this.dataSize)
+                            selRange{l} = 1:this.dataSize(l);
+                        end
+                        outSize(k) = prod(double(this.dataSize(cDim:end)));
+                        break; % jump out ouf for-loop
+                    end
+                elseif isnumeric(S.subs{k})
+                    selRange{cDim} = single(S.subs{k});
+                else
+                    error('unknown string in brackets (e.g. 1:end does not work here)');
+                end
+                outSize(k) = numel(selRange{cDim});
+            end
+            for k=1:numel(selRange)
+                if max(selRange{k}) > this.dataSize(k)
+                    error('selection out of range');
+                end
+            end
+        end
+
+        selRangeSz = ones(1,numel(this.dataSize));
+        for k=1:numel(selRange)
+            selRangeSz(k) = numel(selRange{k});
+        end
+        
+        % now select all indices for the dims that are averaged
+        for k = find(this.flagAverageDim)
+            selRange{k} = 1:this.fullSize(k);
+        end
+    end
+
+    
+    function [ixToRaw, ixToTarget] = calcIndices(this)
+        % calculate indices to target & source(raw)
+        LinIx     = this.Lin - this.skipLin;
+        ParIx     = this.Par - this.skipPar;
+        sz = this.fullSize(3:end); % extra variable needed for octave compatibility
+        ixToTarget = this.sub2ind_double(sz,...
+            LinIx, ParIx, this.Sli, this.Ave, this.Phs, this.Eco,...
+            this.Rep, this.Set, this.Seg, this.Ida, this.Idb,...
+            this.Idc, this.Idd, this.Ide);
+
+        % now calc. inverse index (page table: virtual to physical addresses)
+        % indices of lines that are not measured are zero
+        ixToRaw = zeros(1,prod(this.fullSize(3:end)),'double');
+
+        ixToRaw(ixToTarget) = 1:numel(ixToTarget);
+    end
+end
+
+methods (Static)
+    % helper functions, accessible from outside via <classname>.function()
+    % without an instance of the class.
+    
+    function ro_shift = calcOffcenterShiftRO(slicedata)
+        % calculate ro offcenter shift from mdh's slicedata
+        
+        % slice position
+        pos = slicedata(1:3);
+        
+        %quaternion
+        a = slicedata(5);
+        b = slicedata(6);
+        c = slicedata(7);
+        d = slicedata(4);
+        
+        read_dir = zeros(3,1);
+        read_dir(1) = 2 * (a * b - c * d);
+        read_dir(2) = 1 - 2 * (a^2 + c^2);
+        read_dir(3) = 2 * (b * c + a * d);
+    
+        ro_shift = dot(pos, read_dir);
+    end 
+        
+    function ndx = sub2ind_double(sz, varargin)
+        %SUB2IND_double Linear index from multiple subscripts.
+        %   Works like sub2ind but always returns double
+        %   also slightly faster, but no checks
+        %========================================
+        sz  = double(sz);
+        ndx = double(varargin{end}) - 1;
+        for i = length(sz)-1:-1:1
+            ix  = double(varargin{i});
+            ndx = sz(i)*ndx + ix-1;
+        end
+        ndx = ndx + 1;
+    end % sub2ind_double
+
+    function N = cast2MinimalUint( N )
+        Nmax = max( reshape(N,[],1) );
+        Nmin = min( reshape(N,[],1) );
+        if Nmin < 0 || Nmax > intmax('uint64')
+            return
+        end
+
+        if Nmax > intmax('uint32')
+            idxClass = 'uint64';
+        elseif Nmax > intmax('uint16')
+            idxClass = 'uint32';
+        else
+            idxClass = 'uint16';
+        end
+
+        N = cast( N, idxClass );
+    end % cast2MinimalUint()
+
+end % of methods (Static)
+
+end % classdef

--- a/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_uk.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_uk.m
@@ -1,0 +1,1085 @@
+classdef twix_map_obj_uk < matlab.mixin.Copyable %handle
+% class to hold information about raw data from siemens MRI scanners
+% (currently VB and VD software versions are supported and tested).
+%
+% Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de), Aug/19/2011
+%
+%
+% Modified by Wolf Blecher (wolf.blecher@tuebingen.mpg.de), Apr/26/2012
+% Added reorder index to indicate which lines are reflected
+% Added slice position for sorting, Mai/15/2012
+%
+% Order of many mdh parameters are now stored (including the reflected ADC
+% bit); PE, Jun/14/2012
+%
+% data is now 'memory mapped' and not read until demanded;
+% (see mapVBVD for a description) PE, Aug/02/2012
+%
+% twix_obj.image.unsorted now returns the data in its acq. order
+% [NCol,NCha,nsamples in acq. order], all average flags don't have an
+% influence on the output, but 'flagRemoveOS' still works, PE, Sep/04/13
+%
+properties(Dependent=true)
+    % flags
+    flagRemoveOS        % removes oversampling in read (col) during read operation
+    flagDoAverage       % averages over all avg during read operation
+    flagAverageReps     % averages over all repetitions
+    flagAverageSets     % averages over all sets
+    flagIgnoreSeg       % sum over all segments during read operation
+    flagIgnoreIda       % DLP: added this flag for baselines - sum over all ida during read operation
+    flagSkipToFirstLine % skips lines/partitions up to the first
+                        % actually acquired line/partition
+                        % (e.g. only the center k-space is acquired in
+                        % refscans, we don't want all the leading zeros
+                        % in our data)
+                        % this is the default behaviour for everything
+                        % but image scans (but can be changed manually)
+    flagRampSampRegrid  % perform on-the-fly ramp sampling regridding
+    flagDoRawDataCorrect     %SRY: apply raw data correction factors during read operation
+    
+    RawDataCorrectionFactors %SRY: allow the user to set/get the factors
+    flagReadLastAcq     % read the PC data
+    flagReadLastSeg     % again reading PC data
+end
+
+properties(GetAccess='public', SetAccess='public')
+    flagAverageDim      % new: flags that determines whether certain dim. should be averaged/ignored
+    filename
+    softwareVersion
+    dataType
+end
+
+properties(Dependent=true)
+    dataSize % this is the current output size, depends on fullSize + some flags
+    sqzSize
+end
+
+properties(GetAccess='public', SetAccess='protected')
+    dataDims
+    sqzDims
+
+    NCol  % mdh information
+    NCha  % mdh information
+    NLin  % mdh information
+    NPar  % mdh information
+    NSli  % mdh information
+    NAve  % mdh information
+    NPhs  % mdh information
+    NEco  % mdh information
+    NRep  % mdh information
+    NSet  % mdh information
+    NSeg  % mdh information
+    NIda  % mdh information
+    NIdb  % mdh information
+    NIdc  % mdh information
+    NIdd  % mdh information
+    NIde  % mdh information
+    NAcq  % simple counter
+
+    % mdh information
+    Lin
+    Par
+    Sli
+    Ave
+    Phs
+    Eco
+    Rep
+    Set
+    Seg
+    Ida
+    Idb
+    Idc
+    Idd
+    Ide
+
+    centerCol
+    centerLin
+    centerPar
+    cutOff
+    coilSelect
+    ROoffcenter
+    timeSinceRF
+    IsReflected
+    IsRawDataCorrect %SRY: storage for MDH flag raw data correct
+
+    slicePos
+    freeParam
+    iceParam
+    scancounter
+    timestamp
+    pmutime
+    rampSampTrj
+
+    % memory position in file
+    memPos
+    
+    isBrokenFile % errors when parsing? 
+end
+
+properties(Hidden=true, SetAccess='protected')
+    arg  % arguments
+
+    fullSize % this is the full size of the data set according to the mdhs, i.e. flags
+             % like 'reduceOS' have no influence on it
+
+    freadInfo
+
+    skipLin
+    skipPar
+end
+
+methods
+    % Constructor:
+    function this = twix_map_obj_uk(arg,dataType,fname,version,rstraj)
+
+        if ~exist('dataType','var')
+            this.dataType = 'image';
+        else
+            this.dataType = lower(dataType);
+        end
+
+        this.filename         = fname;
+        this.softwareVersion  = version;
+
+        this.IsReflected      = logical([]);
+        this.IsRawDataCorrect = logical([]); %SRY
+        this.NAcq             = 0;
+        this.isBrokenFile     = false;
+
+        this.setDefaultFlags();
+        if exist('arg','var')
+            % copy relevant arguments from mapVBVD argument list
+            names=fieldnames(arg);
+            for k=1:numel(names)
+                if isfield(this.arg,names{k})
+                    this.arg.(names{k}) = arg.(names{k});
+                end
+            end
+        end
+        this.flagAverageDim(ismember(this.dataDims,'Ave')) = this.arg.doAverage;
+        this.flagAverageDim(ismember(this.dataDims,'Rep')) = this.arg.averageReps;
+        this.flagAverageDim(ismember(this.dataDims,'Set')) = this.arg.averageSets;
+        this.flagAverageDim(ismember(this.dataDims,'Seg')) = this.arg.ignoreSeg;
+        
+        switch this.softwareVersion
+            case 'vb'
+                % every channel has its own full mdh
+                this.freadInfo.szScanHeader    =   0; % [bytes]
+                this.freadInfo.szChannelHeader = 128; % [bytes]
+                this.freadInfo.iceParamSz      =   4;
+            case 'vd'
+                if ( this.arg.doRawDataCorrect )
+                    error('raw data correction for VD not supported/tested yet');
+                end
+                this.freadInfo.szScanHeader    = 192; % [bytes]
+                this.freadInfo.szChannelHeader =  32; % [bytes]
+                this.freadInfo.iceParamSz      =  24; % vd version supports up to 24 ice params
+            otherwise
+                error('software version not supported');
+        end
+
+        if exist('rstraj','var')
+            this.rampSampTrj = rstraj;
+        else
+            this.rampSampTrj        = [];
+            this.arg.rampSampRegrid = false;
+        end
+    end
+
+    function this = readMDH(this, mdh, filePos )
+        % extract all values in all MDHs at once
+        %
+        % data types:
+        % Use double for everything non-logical, both ints and floats. Seems the
+        % most robust way to avoid unexpected cast-issues with very nasty side effects.
+        % Examples: eps(single(16777216)) == 2
+        %           uint32( 10 ) - uint32( 20 ) == 0
+        %           uint16(100) + 1e5 == 65535
+        %           size(1 : 10000 * uint16(1000)) ==  [1  65535]
+        %
+        % The 1st example always hits the timestamps.
+
+        if ~isstruct( mdh ) || isempty( mdh )
+            return
+        end
+
+        this.NAcq     = numel( filePos );
+        sLC           = double( mdh.sLC ) + 1;  % +1: convert to matlab index style
+        evalInfoMask1 = double( mdh.aulEvalInfoMask(:,1) ).';
+
+        % save mdh information for each line
+        this.NCol       = double( mdh.ushSamplesInScan ).';
+        this.NCha       = double( mdh.ushUsedChannels ).';
+        this.Lin        = sLC(:,1).' ;
+        this.Ave        = sLC(:,2).' ;
+        this.Sli        = sLC(:,3).' ;
+        this.Par        = sLC(:,4).' ;
+        this.Eco        = sLC(:,5).' ;
+        this.Phs        = sLC(:,6).' ;
+        this.Rep        = sLC(:,7).' ;
+        this.Set        = sLC(:,8).' ;
+        this.Seg        = sLC(:,9).' ;
+        this.Ida        = sLC(:,10).';
+        this.Idb        = sLC(:,11).';
+        this.Idc        = sLC(:,12).';
+        this.Idd        = sLC(:,13).';
+        this.Ide        = sLC(:,14).';
+
+        this.centerCol   = double( mdh.ushKSpaceCentreColumn ).' + 1;
+        this.centerLin   = double( mdh.ushKSpaceCentreLineNo ).' + 1;
+        this.centerPar   = double( mdh.ushKSpaceCentrePartitionNo ).' + 1;
+        this.cutOff      = double( mdh.sCutOff ).';
+        this.coilSelect  = double( mdh.ushCoilSelect ).';
+        this.ROoffcenter = double( mdh.fReadOutOffcentre ).';
+        this.timeSinceRF = double( mdh.ulTimeSinceLastRF ).';
+        this.IsReflected = logical(min(bitand(evalInfoMask1,2^24),1));
+        this.scancounter = double( mdh.ulScanCounter ).';
+        this.timestamp   = double( mdh.ulTimeStamp ).';
+        this.pmutime     = double( mdh.ulPMUTimeStamp ).';
+        this.IsRawDataCorrect = logical(min(bitand(evalInfoMask1,2^10),1)); %SRY
+        this.slicePos    = double( mdh.SlicePos ).';
+        this.iceParam    = double( mdh.aushIceProgramPara ).';
+        this.freeParam   = double( mdh.aushFreePara ).';
+
+        this.memPos = filePos;
+
+    end % of readMDH
+
+    function this = tryAndFixLastMdh(this)
+        eofWarning = [mfilename() ':UnxpctdEOF'];   % We have it inside this.readData()
+        warning( 'off', eofWarning )    % silence warnings for read...
+        warning( 'off', 'foo:bar'  )    % ... and a stupid placeholder
+
+        isLastAcqGood = false;
+        cnt = 0;
+
+        while ~isLastAcqGood  &&  this.NAcq > 0  && cnt < 100
+            warning( 'foo:bar', 'baz') % make sure that lastwarn() does not return eofWarning
+            try
+                this.clean();
+                this.unsorted(this.NAcq);
+                [~, warnid] = lastwarn();
+                if strcmp( warnid, eofWarning )
+                    error( 'Make sure to go to the catch block.')
+                end
+                isLastAcqGood = true;
+            catch
+                this.isBrokenFile = true;
+                this.NAcq = this.NAcq-1;
+            end
+            cnt = cnt + 1;
+        end
+        
+%         if this.NAcq == 0  ||  cnt > 99    % everything is garbage
+%             warning(  )
+%         end
+
+        warning( 'on', eofWarning )
+    end
+
+    function this = clean(this)
+        
+        if this.NAcq == 0
+            return;
+        end
+
+        % Cut mdh data to actual size. Maybe we rejected acquisitions at the end
+        % due to read errors.
+        fields = { 'NCol', 'NCha',                                                  ...
+                   'Lin', 'Par', 'Sli', 'Ave', 'Phs', 'Eco', 'Rep',                 ...
+                   'Set', 'Seg', 'Ida', 'Idb', 'Idc', 'Idd', 'Ide',                 ...
+                   'centerCol'  ,   'centerLin',   'centerPar',           'cutOff', ...
+                   'coilSelect' , 'ROoffcenter', 'timeSinceRF',      'IsReflected', ...
+                   'scancounter',   'timestamp',     'pmutime', 'IsRawDataCorrect', ...
+                   'slicePos'   ,    'iceParam',   'freeParam',           'memPos'  };
+        
+        nack = this.NAcq;
+        idx = 1:nack;
+
+        for f = fields
+            f1 = f{1};
+            if size(this.(f1),2) > nack   % rarely
+                this.(f1) = this.(f1)(:,idx);       % 1st dim: samples,  2nd dim acquisitions
+            end
+        end
+
+        this.NLin = max(this.Lin);
+        this.NPar = max(this.Par);
+        this.NSli = max(this.Sli);
+        this.NAve = max(this.Ave);
+        this.NPhs = max(this.Phs);
+        this.NEco = max(this.Eco);
+        this.NRep = max(this.Rep);
+        this.NSet = max(this.Set);
+        this.NSeg = max(this.Seg);
+        this.NIda = max(this.Ida);
+        this.NIdb = max(this.Idb);
+        this.NIdc = max(this.Idc);
+        this.NIdd = max(this.Idd);
+        this.NIde = max(this.Ide);
+
+        % ok, let us assume for now that all NCol and NCha entries are
+        % the same for all mdhs:
+        this.NCol = this.NCol(1);
+        this.NCha = this.NCha(1);
+
+        this.dataDims = {'Col','Cha','Lin','Par','Sli','Ave','Phs',...
+            'Eco','Rep','Set','Seg','Ida','Idb','Idc','Idd','Ide'};
+
+        if strcmp(this.dataType,'refscan')
+            %pehses: check for lines with 'negative' line/partition numbers
+            %this can happen when the reference scan line/partition range
+            %exceeds the one of the actual imaging scan
+            if this.NLin>65500  %uint overflow check
+                this.Lin  = mod(this.Lin + (65536 - min(this.Lin(this.Lin>65500))),65536)+1;
+                this.NLin = max(this.Lin);
+            end
+            if this.NPar>65500  %uint overflow check
+                this.Par  = mod(this.Par + (65536 - min(this.Par(this.Par>65500))),65536)+1;
+                this.NPar = max(this.Par);
+            end
+        end
+
+        % to reduce the matrix sizes of non-image scans, the size
+        % of the refscan_obj()-matrix is reduced to the area of the
+        % actually scanned acs lines (the outer part of k-space
+        % that is not scanned is not filled with zeros)
+        % this behaviour is controlled by flagSkipToFirstLine which is
+        % set to true by default for everything but image scans
+        if ~this.flagSkipToFirstLine
+            % the output matrix should include all leading zeros
+            this.skipLin = 0;
+            this.skipPar = 0;
+        else
+            % otherwise, cut the matrix size to the start of the
+            % first actually scanned line/partition (e.g. the acs/
+            % phasecor data is only acquired in the k-space center)
+            this.skipLin = min(this.Lin)-1;
+            this.skipPar = min(this.Par)-1;
+        end
+        NLinAlloc = max(1, this.NLin - this.skipLin);
+        NParAlloc = max(1, this.NPar - this.skipPar);
+
+        this.fullSize = [ this.NCol this.NCha NLinAlloc NParAlloc...
+                          this.NSli this.NAve this.NPhs this.NEco...
+                          this.NRep this.NSet this.NSeg this.NIda...
+                          this.NIdb this.NIdc this.NIdd this.NIde ];
+
+        nByte = this.NCha*(this.freadInfo.szChannelHeader+8*this.NCol);
+
+        % size for fread
+        this.freadInfo.sz    = [2 nByte/8];
+        % reshape size
+        this.freadInfo.shape = [this.NCol+this.freadInfo.szChannelHeader/8 ...
+                               , this.NCha];
+        % we need to cut MDHs from fread data
+        this.freadInfo.cut   = this.freadInfo.szChannelHeader/8 + (1 : this.NCol);
+
+    end % of clean
+
+
+    function varargout = subsref(this, S)
+        % this is where the magic happens
+        % Now seriously. Overloading of the subsref-method and working
+        % with a gazillion indices got really messy really fast. At
+        % some point, I should probably clean this code up a bit. But
+        % good news everyone: It seems to work.
+        switch S(1).type
+            case '.'
+                % We don't want to manage method/variable calls, so we'll
+                % simply call the built-in subsref-function in this case.
+                if nargout == 0
+                    varargout{1} = builtin('subsref', this, S); % CTR fix.
+                else
+                    varargout      = cell(1, nargout);
+                    [varargout{:}] = builtin('subsref', this, S);
+                end
+                return;
+            case {'()','{}'}
+            otherwise
+                error('operator not supported');
+        end
+
+        [selRange,selRangeSz,outSize] = this.calcRange(S(1));
+
+    	% calculate page table (virtual to physical addresses)
+        % this is now done every time, i.e. result is no longer saved in
+        % a property - slower but safer (and easier to keep track of updates)
+        ixToRaw = this.calcIndices;
+        
+        tmp = reshape(1:prod(double(this.fullSize(3:end))), this.fullSize(3:end));
+        tmp = tmp(selRange{3:end});
+        ixToRaw = ixToRaw(tmp); clear tmp;
+        ixToRaw = ixToRaw(:);
+        % delete all entries that point to zero (the "NULL"-pointer)
+        notAcquired = (ixToRaw == 0);
+        ixToRaw (notAcquired) = []; clear notAcquired;
+
+        % calculate ixToTarg for possibly smaller, shifted + segmented
+        % target matrix:
+        cIx = ones(14, numel(ixToRaw), 'single');
+        if ~this.flagAverageDim(3)
+            cIx( 1,:) = this.Lin(ixToRaw) - this.skipLin;
+        end
+        if ~this.flagAverageDim(4)
+            cIx( 2,:) = this.Par(ixToRaw) - this.skipPar;
+        end
+        if ~this.flagAverageDim(5)
+            cIx( 3,:) = this.Sli(ixToRaw);
+        end
+        if ~this.flagAverageDim(6)
+            cIx( 4,:) = this.Ave(ixToRaw);
+        end
+        if ~this.flagAverageDim(7)
+            cIx( 5,:) = this.Phs(ixToRaw);
+        end
+        if ~this.flagAverageDim(8)
+            cIx( 6,:) = this.Eco(ixToRaw);
+        end
+        if ~this.flagAverageDim(9)
+            cIx( 7,:) = this.Rep(ixToRaw);
+        end
+        if ~this.flagAverageDim(10)
+            cIx( 8,:) = this.Set(ixToRaw);
+        end
+        if ~this.flagAverageDim(11)
+            cIx( 9,:) = this.Seg(ixToRaw);
+        end
+        if ~this.flagAverageDim(12)
+            cIx(10,:) = this.Ida(ixToRaw);
+        end
+        if ~this.flagAverageDim(13)
+            cIx(11,:) = this.Idb(ixToRaw);
+        end
+        if ~this.flagAverageDim(14)
+            cIx(12,:) = this.Idc(ixToRaw);
+        end
+        if ~this.flagAverageDim(15)
+            cIx(13,:) = this.Idd(ixToRaw);
+        end
+        if ~this.flagAverageDim(16)
+            cIx(14,:) = this.Ide(ixToRaw);
+        end
+
+        % make sure that indices fit inside selection range
+        for k=3:numel(selRange)
+            tmp = cIx(k-2,:);
+            for l=1:numel(selRange{k})
+                cIx(k-2,tmp==selRange{k}(l)) = l;
+            end
+        end
+
+        ixToTarg = this.sub2ind_double(selRangeSz(3:end),cIx(1,:),cIx(2,:),cIx(3,:),...
+            cIx(4,:),cIx(5,:),cIx(6,:),cIx(7,:),cIx(8,:),cIx(9,:),...
+            cIx(10,:),cIx(11,:),cIx(12,:),cIx(13,:),cIx(14,:));
+
+        mem = this.memPos(ixToRaw);
+        % sort mem for quicker access, sort cIxToTarg/Raw accordingly
+        [mem,ix]  = sort(mem);
+        ixToTarg = ixToTarg(ix);
+        ixToRaw  = ixToRaw(ix);
+        clear ix;
+
+        % For a call of type data{:,:,1:3} matlab expects more than one
+        % output variable (three in this case) and will throw an error
+        % otherwise. This is a lazy way (and the only one I know of) to
+        % fix this.
+        varargout    = cell(1, nargout);
+        varargout{1} = this.readData(mem,ixToTarg,ixToRaw,selRange,selRangeSz,outSize);
+    end % of subsref
+
+    
+    function out = unsorted(this,ival)
+        % returns the unsorted data [NCol,NCha,#samples in acq. order]
+        if ~exist('ival','var')
+            mem = this.memPos;
+        else
+            mem = this.memPos(ival);
+        end
+        out = this.readData(mem);
+    end
+
+    
+    function out = readData(this,mem,cIxToTarg,cIxToRaw,selRange,selRangeSz,outSize)
+
+        if ~exist('outSize','var')
+            selRange{1} = ':';
+            selRange{2} = ':';
+            outSize = [this.dataSize(1:2),numel(mem)];
+            selRangeSz = outSize;
+            cIxToTarg = 1:selRangeSz(3);
+            cIxToRaw  = cIxToTarg;
+        else
+            if isequal( selRange{1}(:), (1:this.dataSize(1)).' )
+                selRange{1} = ':';
+            end
+            if isequal( selRange{2}(:), (1:this.dataSize(2)).' )
+                selRange{2} = ':';
+            end
+        end
+        out = complex(zeros(outSize,'single'));
+        out = reshape(out, selRangeSz(1), selRangeSz(2), []);
+
+        if isempty( mem )
+            out = reshape(out,outSize);
+            return
+        end
+
+        cIxToTarg = this.cast2MinimalUint( cIxToTarg );
+
+        % subsref overloading makes this.that-calls slow, so we need to
+        % avoid them whenever possible
+        szScanHeader = this.freadInfo.szScanHeader;
+        readSize     = this.freadInfo.sz;
+        readShape    = this.freadInfo.shape;
+        readCut      = this.freadInfo.cut;
+        keepOS       = [1:this.NCol/4, 1+this.NCol*3/4:this.NCol];
+        bRemoveOS    = this.arg.removeOS;
+        bIsReflected = this.IsReflected( cIxToRaw );
+        bRegrid      = this.flagRampSampRegrid && numel(this.rampSampTrj);
+        %SRY store information about raw data correction
+        bDoRawDataCorrect = this.arg.doRawDataCorrect;
+        bIsRawDataCorrect = this.IsRawDataCorrect( cIxToRaw );
+        isBrokenRead      = false;
+        if (bDoRawDataCorrect)
+            rawDataCorrect = this.arg.rawDataCorrectionFactors;
+        end
+
+        % MiVö: Raw data are read line-by-line in portions of 2xNColxNCha float32 points (2 for complex).
+        % Computing and sorting(!) on these small portions is quite expensive, esp. when
+        % it employs non-sequential memory paths. Examples are non-linear k-space acquisition
+        % or reflected lines.
+        % This can be sped up if slightly larger blocks of raw data are collected, first.
+        % Whenever a block is full, we do all those operations and save it in the final "out" array.
+        % What's a good block size? Depends on data size and machine (probably L2/L3/L4 cache sizes).
+        % So...? Start with a small block, measure the time-per-line and double block size until
+        % a minimum is found. Seems sufficiently robust to end up in a close-to-optimal size for every
+        % machine and data.
+        blockSz   = 2;          % size of blocks; must be 2^n; will be increased
+        doLockblockSz = false;  % whether blockSZ should be left untouched
+        tprev     = inf;        % previous time-per-line
+        blockCtr  = 0;
+        blockInit = -inf(readShape(1), readShape(2), blockSz, 'single'); %init with garbage
+        blockInit = complex( blockInit );
+        block     = blockInit;
+        
+        if bRegrid
+            v1       = single(1:selRangeSz(2));
+            v2       = single(1:blockSz);
+            rsTrj    = {this.rampSampTrj,v1,v2};
+            trgTrj   = linspace(min(this.rampSampTrj),max(this.rampSampTrj),this.NCol);
+            trgTrj   = {trgTrj,v1,v2};
+        end
+    
+        % counter for proper scaling of averages/segments
+        count_ave = zeros([1 1 size(out,3)],'single');
+        kMax      = numel( mem );   % max loop index
+
+        fid = this.fileopen();
+
+        for k = 1:kMax
+            % skip scan header
+            fseek(fid,mem(k) + szScanHeader,'bof');
+            raw = fread(fid, readSize, 'float=>single').';
+
+            % MiVö: With incomplete files fread() returns less than readSize points. The subsequent reshape will therefore error out.
+            %       We could check if numel(raw) == prod(readSize), but people recommend exception handling for performance
+            %       reasons. Do it.
+            try
+                raw = reshape( complex(raw(:,1), raw(:,2)), readShape);
+            catch exc
+                offset_bytes = mem(k) + szScanHeader;
+                %remainingSz = readSize(2) - size(raw,1);
+                warning( [mfilename() ':UnxpctdEOF'],  ...
+                          [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                            'Actual read size is [%s], desired size was: [%s]\n'                    ...
+                            'Will ignore this line and stop reading.\n'                             ...
+                            '=== MATLABs error message ================\n'                          ...
+                            exc.message                                                             ...
+                            '\n=== end of error =========================\n'                        ...
+                            ], offset_bytes, offset_bytes/1024^3, num2str(size(raw)), num2str(readSize.') )
+
+                % Reject this data fragment. To do so, init with the values of blockInit
+                clear raw
+                raw( 1:prod(readShape) ) = blockInit(1);
+                raw = reshape( raw, readShape );
+                isBrokenRead = true;   % remember it and bail out later
+            end
+
+            blockCtr = blockCtr + 1;
+            block(:,:,blockCtr) = raw;  % fast serial storage in a cache array
+            
+            % Do expensive computations and reorderings on the gathered block.
+            % Unfortunately, a lot of code is necessary, but that is executed much less
+            % frequent, so its worthwhile for speed.
+            % TODO: Do *everything* block-by-block
+            if blockCtr == blockSz || k == kMax || (isBrokenRead && blockCtr > 1)
+                s = tic;    % measure the time to process a block of data
+            
+                % remove MDH data from block:
+                block = block(readCut,:,:);
+
+                if bRegrid
+                    F     = griddedInterpolant(rsTrj,block);
+                    block = F(trgTrj);
+                end
+                
+                if sum(isnan(block(:)))>0
+                    keyboard
+                end
+
+                if bRemoveOS % remove oversampling in read
+                    block = ifft( block,[],1);
+                    block =  fft( block(keepOS,:,:),[],1);
+                end
+                                    
+                if ( bDoRawDataCorrect && bIsRawDataCorrect(k) )
+                    %SRY apply raw data correction if necessary
+                    block = bsxfun(@times, block, rawDataCorrect);
+                end
+                
+                ix = 1 + k - blockCtr : k;
+                if blockCtr ~= blockSz
+                    block = block(:,:,1:blockCtr);
+                end
+                
+                isRefl = bIsReflected(ix);
+                block(:,:,isRefl) = block(end:-1:1,:,isRefl);
+                
+                if ~isequal(selRange{1},':') || ~isequal(selRange{2},':')
+                    block = block( selRange{1}, selRange{2}, : );    % a bit slow
+                end
+                
+                [sortIdx, I] = sort( cIxToTarg(ix), 'ascend' );
+                block = block(:,:,I);     % reorder according to sorted target indices
+
+                % Mark duplicate indices with 1; we'll have to treat them special for proper averaging
+                % Bonus: The very first storage can be made much faster, because it's in-place.
+                %        Matlab urgently needs a "+=" operater, which makes "A(:,:,idx) = A(:,:,idx) + B"
+                %        in-place and more readable.
+                isDupe  = [ false, diff(sortIdx) == 0 ];
+
+                idx1 = sortIdx(~isDupe);     % acquired once in this block
+                idxN = sortIdx( isDupe);     % acquired multiple times
+
+                count_ave(idx1) = count_ave(idx1) + 1;
+
+                if isempty( idxN )
+                    % no duplicates
+                    if all( count_ave(idx1) == 1 )  % first acquisition of this line
+                        out(:,:,idx1) = block;                              % fast
+                    else
+                        out(:,:,idx1) = out(:,:,idx1) + block;              % slow
+                    end
+                else
+                    out(:,:,idx1) = out(:,:,idx1) + block(:,:,~isDupe);     % slower
+
+                    block = block(:,:,isDupe);
+                    for n = 1:numel(idxN)
+                        out(:,:,idxN(n)) = out(:,:,idxN(n)) + block(:,:,n); % snail :-)
+                        count_ave(idxN(n)) = count_ave(idxN(n)) + 1;
+                    end
+                end
+
+                % At the first few iterations, evaluate the spent time-per-line and decide
+                % what to do with the block size.
+                if ~doLockblockSz
+                    t = 1e6 * toc(s)/blockSz;   % micro seconds
+
+                    if t <= 1.1 * tprev % allow 10% inaccuracy. Usually bigger == better
+                        % New block size was faster. Go a step further.
+                        blockSz = blockSz * 2;
+                        blockInit = cat(3, blockInit, blockInit);
+                    else
+                        % regression; reset size and lock it
+                        blockSz = max( blockSz/2, 1 );
+                        blockInit = blockInit(:,:,1:blockSz);
+                        doLockblockSz = true;
+                    end
+                    if bRegrid
+                        rsTrj{3}  = single(1:blockSz);
+                        trgTrj{3} = rsTrj{3};
+                    end
+                    tprev = t;
+                end
+                    
+                blockCtr = 0;
+                block = blockInit;  % reset to garbage
+            end
+
+            if isBrokenRead
+                this.isBrokenFile = true;
+                break
+            end
+        end
+
+        fclose(fid);
+
+        % proper scaling (we don't want to sum our data but average it)
+        % For large "out" bsxfun(@rdivide,out,count_ave) is incredibly faster than
+        % bsxfun(@times,out,count_ave)!
+        % @rdivide is also running in parallel, while @times is not. :-/
+        if any( reshape(count_ave,[],1) > 1 )
+            clearvars -except  out  count_ave  outSize
+            count_ave = max( 1, count_ave );
+            out       = bsxfun( @rdivide, out, count_ave);
+        end
+
+        out = reshape(out,outSize);
+    end % of readData
+
+
+    function setDefaultFlags(this)
+        % method to set flags to default values
+        this.arg.removeOS            = false;
+        this.arg.rampSampRegrid      = false;
+        this.arg.doAverage           = false;
+        this.arg.averageReps         = false;
+        this.arg.averageSets         = false;
+        this.arg.ignoreSeg           = false;
+        this.arg.doRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        if ~isfield(this.arg,'rawDataCorrectionFactors')
+            this.arg.rawDataCorrectionFactors = [];
+        end
+    end
+
+    function dummy = resetFlags(this)
+        % method to reset flags to default values
+        this.flagRemoveOS            = false;
+        this.flagRampSampRegrid      = false;
+        this.flagDoRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        dummy = [];
+    end
+    
+    
+    function out = get.dataSize(this)
+        out = this.fullSize;
+        
+        if this.arg.removeOS
+            ix = ismember(this.dataDims, 'Col');
+            out(ix) = this.NCol/2;
+        end
+                
+        if this.flagAverageDim(1) || this.flagAverageDim(2)
+            warning('averaging in col and cha dim not supported, resetting flag');
+            this.flagAverageDim(1:2) = false;
+        end
+        
+        out(this.flagAverageDim) = 1;
+    end
+    
+    
+    function out = get.sqzSize(this)
+        % calculate sqzSize and sqzDims
+        out = this.dataSize(1);
+        this.sqzDims    = [];
+        this.sqzDims{1} = 'Col';
+        c = 1;
+        for k=2:numel(this.dataSize)
+            if this.dataSize(k)>1
+                c = c+1;
+                out(c) = this.dataSize(k);
+                this.sqzDims{c} = this.dataDims{k};
+            end
+        end
+    end
+    
+        
+    function set.flagRemoveOS(this,val)
+        % set method for removeOS
+        this.arg.removeOS = logical(val);
+    end
+    
+    function out = get.flagRemoveOS(this)
+        out = this.arg.removeOS;
+    end
+
+
+    function set.flagDoAverage(this,val)
+        ix = ismember(this.dataDims, 'Ave');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagDoAverage(this)
+        ix = ismember(this.dataDims, 'Ave');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagAverageReps(this,val)
+        ix = ismember(this.dataDims, 'Rep');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageReps(this)
+        ix = ismember(this.dataDims, 'Rep');
+        out = this.flagAverageDim(ix);
+    end
+
+
+    function set.flagAverageSets(this,val)
+        ix = ismember(this.dataDims, 'Set');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageSets(this)
+        ix = ismember(this.dataDims, 'Set');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagIgnoreSeg(this,val)
+        ix = ismember(this.dataDims, 'Seg');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagIgnoreSeg(this)
+        ix = ismember(this.dataDims, 'Seg');
+        out = this.flagAverageDim(ix);
+    end
+
+    %DLP 17 Dec 2018
+    function set.flagIgnoreIda(this,val)                %DLP (7 December 2018) added this flag to sum over baselines 
+        ix = ismember(this.dataDims, 'Ida');            % to eliminate sparse data structure
+        this.flagAverageDim(ix) = val;
+    end
+    function out = get.flagIgnoreIda(this)
+        ix = ismember(this.dataDims, 'Ida');
+        out = this.flagAverageDim(ix);
+    end
+ % end DLP 17 Dec 2018   
+    
+    function set.flagSkipToFirstLine(this,val)
+        val = logical(val);
+        if val ~= this.arg.skipToFirstLine
+            this.arg.skipToFirstLine = val;
+
+            if this.arg.skipToFirstLine
+                this.skipLin = min(this.Lin)-1;
+                this.skipPar = min(this.Par)-1;
+            else
+                this.skipLin = 0;
+                this.skipPar = 0;
+            end
+            NLinAlloc = max(1, this.NLin - this.skipLin);
+            NParAlloc = max(1, this.NPar - this.skipPar);
+            this.fullSize(3:4) = [NLinAlloc NParAlloc];
+        end
+    end
+
+
+    function out = get.flagSkipToFirstLine(this)
+        out = this.arg.skipToFirstLine;
+    end
+
+    function out = get.flagRampSampRegrid(this)
+        out = this.arg.rampSampRegrid;
+    end
+
+    function set.flagRampSampRegrid(this, val)
+        val = logical(val);
+        if (val == true && isempty(this.rampSampTrj))
+            error('No trajectory for regridding available');
+        end
+        this.arg.rampSampRegrid = val;
+    end
+
+    %SRY: accessor methods for raw data correction
+    function out = get.flagDoRawDataCorrect(this)
+        out = this.arg.doRawDataCorrect;
+    end
+
+    function set.flagDoRawDataCorrect(this, val)
+        val = logical(val);
+        if (val == true && strcmp(this.softwareVersion, 'vd'))
+            error('raw data correction for VD not supported/tested yet');
+        end
+
+        this.arg.doRawDataCorrect = val;
+    end
+
+    function out = get.RawDataCorrectionFactors(this)
+        out = this.arg.rawDataCorrectionFactors;
+    end
+
+    function set.RawDataCorrectionFactors(this, val)
+        %this may not work if trying to set the factors before NCha has
+        %a meaningful value (ie before calling clean)
+        if (~isrow(val) || length(val) ~= this.NCha)
+            error('RawDataCorrectionFactors must be a 1xNCha row vector');
+        end
+        this.arg.rawDataCorrectionFactors = val;
+    end
+
+end
+
+methods (Access='protected')
+    % helper functions
+
+    function fid = fileopen(this)
+        % look out for unlikely event that someone is switching between
+        % windows and unix systems:
+        [path,name,ext] = fileparts(this.filename);
+        this.filename   = fullfile(path,[name ext]);
+
+        % test access
+        if numel(dir(this.filename))==0
+            % update path when file of same name can be found in current
+            % working dir. -- otherwise throw error
+            [oldpath,name,ext] = fileparts(this.filename);
+            newloc = fullfile(pwd,[name ext]);
+            if numel(dir(newloc))==1
+                fprintf('Warning: File location updated from "%s" to current working directory.\n',oldpath);
+                this.filename = newloc;
+            else
+                error(['File "' this.filename '" not found.']);
+            end
+        end
+        fid = fopen(this.filename);
+    end
+
+    
+    function [selRange,selRangeSz,outSize] = calcRange(this,S)
+
+        switch S.type
+            case '()'
+                bSqueeze = false;
+            case '{}'
+                bSqueeze = true;
+        end
+
+        selRange = num2cell(ones(1,numel(this.dataSize)));
+        outSize  = ones(1,numel(this.dataSize));
+
+        if ( isempty(S.subs) || strcmpi(S.subs(1),'') )
+            % obj(): shortcut to select all data
+            % unfortunately, matlab does not allow the statement
+            % obj{}, so we can't use it...
+            % alternative: obj{''} (obj('') also works)
+            for k=1:numel(this.dataSize)
+                selRange{k}   = 1:this.dataSize(k);
+            end
+            if ~bSqueeze
+                outSize = this.dataSize;
+            else
+                outSize = this.sqzSize;
+            end
+        else
+            for k=1:numel(S.subs)
+                if ~bSqueeze
+                    cDim = k; % nothing to do
+                else
+                    % we need to rearrange selRange from squeezed
+                    % to original order
+                    cDim = find(strcmp(this.dataDims,this.sqzDims{k}) == 1);
+                end
+                if strcmp(S.subs{k},':')
+                    if k<numel(S.subs)
+                        selRange  {cDim} = 1:this.dataSize(cDim);
+                    else % all later dimensions selected and 'vectorized'!
+                        for l=cDim:numel(this.dataSize)
+                            selRange{l} = 1:this.dataSize(l);
+                        end
+                        outSize(k) = prod(double(this.dataSize(cDim:end)));
+                        break; % jump out ouf for-loop
+                    end
+                elseif isnumeric(S.subs{k})
+                    selRange{cDim} = single(S.subs{k});
+                else
+                    error('unknown string in brackets (e.g. 1:end does not work here)');
+                end
+                outSize(k) = numel(selRange{cDim});
+            end
+            for k=1:numel(selRange)
+                if max(selRange{k}) > this.dataSize(k)
+                    error('selection out of range');
+                end
+            end
+        end
+
+        selRangeSz = ones(1,numel(this.dataSize));
+        for k=1:numel(selRange)
+            selRangeSz(k) = numel(selRange{k});
+        end
+        
+        % now select all indices for the dims that are averaged
+        for k = find(this.flagAverageDim)
+            selRange{k} = 1:this.fullSize(k);
+        end
+    end
+
+    
+    function [ixToRaw, ixToTarget] = calcIndices(this)
+        % calculate indices to target & source(raw)
+        LinIx     = this.Lin - this.skipLin;
+        ParIx     = this.Par - this.skipPar;
+        ixToTarget = this.sub2ind_double(this.fullSize(3:end),...
+            LinIx, ParIx, this.Sli, this.Ave, this.Phs, this.Eco,...
+            this.Rep, this.Set, this.Seg, this.Ida, this.Idb,...
+            this.Idc, this.Idd, this.Ide);
+
+        % now calc. inverse index (page table: virtual to physical addresses)
+        % indices of lines that are not measured are zero
+        ixToRaw = zeros(1,prod(this.fullSize(3:end)),'double');
+
+        ixToRaw(ixToTarget) = 1:numel(ixToTarget);
+    end
+end
+
+methods (Static)
+    % helper functions, accessible from outside via <classname>.function()
+    % without an instance of the class.
+
+    function ndx = sub2ind_double(sz,varargin)
+        %SUB2IND_double Linear index from multiple subscripts.
+        %   Works like sub2ind but always returns double
+        %   also slightly faster, but no checks
+        %========================================
+        sz  = double(sz);
+        ndx = double(varargin{end}) - 1;
+        for i = length(sz)-1:-1:1
+            ix  = double(varargin{i});
+            ndx = sz(i)*ndx + ix-1;
+        end
+        ndx = ndx + 1;
+    end % sub2ind_double
+
+    function N = cast2MinimalUint( N )
+        Nmax = max( reshape(N,[],1) );
+        Nmin = min( reshape(N,[],1) );
+        if Nmin < 0 || Nmax > intmax('uint64')
+            return
+        end
+
+        if Nmax > intmax('uint32')
+            idxClass = 'uint64';
+        elseif Nmax > intmax('uint16')
+            idxClass = 'uint32';
+        else
+            idxClass = 'uint16';
+        end
+
+        N = cast( N, idxClass );
+    end % cast2MinimalUint()
+
+end % of methods (Static)
+
+end % classdef

--- a/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_ukHO.m
+++ b/matlab/read_kspace_dependencies/mapVBVD/twix_map_obj_ukHO.m
@@ -1,0 +1,1139 @@
+classdef twix_map_obj_ukHO < matlab.mixin.Copyable %handle
+% class to hold information about raw data from siemens MRI scanners
+% (currently VB and VD software versions are supported and tested).
+%
+% Author: Philipp Ehses (philipp.ehses@tuebingen.mpg.de), Aug/19/2011
+%
+%
+% Modified by Wolf Blecher (wolf.blecher@tuebingen.mpg.de), Apr/26/2012
+% Added reorder index to indicate which lines are reflected
+% Added slice position for sorting, Mai/15/2012
+%
+% Order of many mdh parameters are now stored (including the reflected ADC
+% bit); PE, Jun/14/2012
+%
+% data is now 'memory mapped' and not read until demanded;
+% (see mapVBVD for a description) PE, Aug/02/2012
+%
+% twix_obj.image.unsorted now returns the data in its acq. order
+% [NCol,NCha,nsamples in acq. order], all average flags don't have an
+% influence on the output, but 'flagRemoveOS' still works, PE, Sep/04/13
+%
+properties(Dependent=true)
+    % flags
+    flagRemoveOS        % removes oversampling in read (col) during read operation
+    flagDoAverage       % averages over all avg during read operation
+    flagAverageReps     % averages over all repetitions
+    flagAverageSets     % averages over all sets
+    flagIgnoreSeg       % sum over all segments during read operation
+    flagIgnoreIda       % DLP: added this flag for baselines - sum over all ida during read operation
+    flagSkipToFirstLine % skips lines/partitions up to the first
+                        % actually acquired line/partition
+                        % (e.g. only the center k-space is acquired in
+                        % refscans, we don't want all the leading zeros
+                        % in our data)
+                        % this is the default behaviour for everything
+                        % but image scans (but can be changed manually)
+    flagRampSampRegrid  % perform on-the-fly ramp sampling regridding
+    flagDoRawDataCorrect     %SRY: apply raw data correction factors during read operation
+    
+    RawDataCorrectionFactors %SRY: allow the user to set/get the factors
+    flagReadLastAcq     % read the PC data
+    flagReadLastSeg     % again reading PC data
+end
+
+properties(GetAccess='public', SetAccess='public')
+    flagAverageDim      % new: flags that determines whether certain dim. should be averaged/ignored
+    filename
+    softwareVersion
+    dataType
+end
+
+properties(Dependent=true)
+    dataSize % this is the current output size, depends on fullSize + some flags
+    sqzSize
+end
+
+properties(GetAccess='public', SetAccess='protected')
+    dataDims
+    sqzDims
+
+    NCol  % mdh information
+    NCha  % mdh information
+    NLin  % mdh information
+    NPar  % mdh information
+    NSli  % mdh information
+    NAve  % mdh information
+    NPhs  % mdh information
+    NEco  % mdh information
+    NRep  % mdh information
+    NSet  % mdh information
+    NSeg  % mdh information
+    NIda  % mdh information
+    NIdb  % mdh information
+    NIdc  % mdh information
+    NIdd  % mdh information
+    NIde  % mdh information
+    NAcq  % simple counter
+
+    % mdh information
+    Lin
+    Par
+    Sli
+    Ave
+    Phs
+    Eco
+    Rep
+    Set
+    Seg
+    Ida
+    Idb
+    Idc
+    Idd
+    Ide
+
+    centerCol
+    centerLin
+    centerPar
+    cutOff
+    coilSelect
+    ROoffcenter
+    timeSinceRF
+    IsReflected
+    IsRawDataCorrect %SRY: storage for MDH flag raw data correct
+
+    slicePos
+    freeParam
+    iceParam
+    scancounter
+    timestamp
+    pmutime
+    rampSampTrj
+
+    % memory position in file
+    memPos
+    
+    isBrokenFile % errors when parsing? 
+end
+
+properties(Hidden=true, SetAccess='protected')
+    arg  % arguments
+
+    fullSize % this is the full size of the data set according to the mdhs, i.e. flags
+             % like 'reduceOS' have no influence on it
+
+    freadInfo
+
+    skipLin
+    skipPar
+end
+
+methods
+    % Constructor:
+    function this = twix_map_obj_ukHO(arg,dataType,fname,version,rstraj)
+
+        if ~exist('dataType','var')
+            this.dataType = 'image';
+        else
+            this.dataType = lower(dataType);
+        end
+
+        this.filename         = fname;
+        this.softwareVersion  = version;
+
+        this.IsReflected      = logical([]);
+        this.IsRawDataCorrect = logical([]); %SRY
+        this.NAcq             = 0;
+        this.isBrokenFile     = false;
+
+        % HOD
+        this.dataDims = {'Col','Cha','Lin','Par','Sli','Ave','Phs',...
+            'Eco','Rep','Set','Seg','Ida','Idb','Idc','Idd','Ide'};
+
+        this.setDefaultFlags();
+        if exist('arg','var')
+            % copy relevant arguments from mapVBVD argument list
+            names=fieldnames(arg);
+            for k=1:numel(names)
+                if isfield(this.arg,names{k})
+                    this.arg.(names{k}) = arg.(names{k});
+                end
+            end
+        end
+        this.flagAverageDim(ismember(this.dataDims,'Ave')) = this.arg.doAverage;
+        this.flagAverageDim(ismember(this.dataDims,'Rep')) = this.arg.averageReps;
+        this.flagAverageDim(ismember(this.dataDims,'Set')) = this.arg.averageSets;
+        this.flagAverageDim(ismember(this.dataDims,'Seg')) = this.arg.ignoreSeg;
+        
+        switch this.softwareVersion
+            case 'vb'
+                % every channel has its own full mdh
+                this.freadInfo.szScanHeader    =   0; % [bytes]
+                this.freadInfo.szChannelHeader = 128; % [bytes]
+                this.freadInfo.iceParamSz      =   4;
+            case 'vd'
+                if ( this.arg.doRawDataCorrect )
+                    error('raw data correction for VD not supported/tested yet');
+                end
+                this.freadInfo.szScanHeader    = 192; % [bytes]
+                this.freadInfo.szChannelHeader =  32; % [bytes]
+                this.freadInfo.iceParamSz      =  24; % vd version supports up to 24 ice params
+            otherwise
+                error('software version not supported');
+        end
+
+        if exist('rstraj','var')
+            this.rampSampTrj = rstraj;
+        else
+            this.rampSampTrj        = [];
+            this.arg.rampSampRegrid = false;
+        end
+    end
+
+    function this = readMDH(this, mdh, filePos )
+        % extract all values in all MDHs at once
+        %
+        % data types:
+        % Use double for everything non-logical, both ints and floats. Seems the
+        % most robust way to avoid unexpected cast-issues with very nasty side effects.
+        % Examples: eps(single(16777216)) == 2
+        %           uint32( 10 ) - uint32( 20 ) == 0
+        %           uint16(100) + 1e5 == 65535
+        %           size(1 : 10000 * uint16(1000)) ==  [1  65535]
+        %
+        % The 1st example always hits the timestamps.
+
+        if ~isstruct( mdh ) || isempty( mdh )
+            return
+        end
+
+        this.NAcq     = numel( filePos );
+        sLC           = double( mdh.sLC ) + 1;  % +1: convert to matlab index style
+        evalInfoMask1 = double( mdh.aulEvalInfoMask(:,1) ).';
+
+        % save mdh information for each line
+        this.NCol       = double( mdh.ushSamplesInScan ).';
+        this.NCha       = double( mdh.ushUsedChannels ).';
+        this.Lin        = sLC(:,1).' ;
+        this.Ave        = sLC(:,2).' ;
+        this.Sli        = sLC(:,3).' ;
+        this.Par        = sLC(:,4).' ;
+        this.Eco        = sLC(:,5).' ;
+        this.Phs        = sLC(:,6).' ;
+        this.Rep        = sLC(:,7).' ;
+        this.Set        = sLC(:,8).' ;
+        this.Seg        = sLC(:,9).' ;
+        this.Ida        = sLC(:,10).';
+        this.Idb        = sLC(:,11).';
+        this.Idc        = sLC(:,12).';
+        this.Idd        = sLC(:,13).';
+        this.Ide        = sLC(:,14).';
+
+        this.centerCol   = double( mdh.ushKSpaceCentreColumn ).' + 1;
+        this.centerLin   = double( mdh.ushKSpaceCentreLineNo ).' + 1;
+        this.centerPar   = double( mdh.ushKSpaceCentrePartitionNo ).' + 1;
+        this.cutOff      = double( mdh.sCutOff ).';
+        this.coilSelect  = double( mdh.ushCoilSelect ).';
+        this.ROoffcenter = double( mdh.fReadOutOffcentre ).';
+        this.timeSinceRF = double( mdh.ulTimeSinceLastRF ).';
+        this.IsReflected = logical(min(bitand(evalInfoMask1,2^24),1));
+        this.scancounter = double( mdh.ulScanCounter ).';
+        this.timestamp   = double( mdh.ulTimeStamp ).';
+        this.pmutime     = double( mdh.ulPMUTimeStamp ).';
+        this.IsRawDataCorrect = logical(min(bitand(evalInfoMask1,2^10),1)); %SRY
+        this.slicePos    = double( mdh.SlicePos ).';
+        this.iceParam    = double( mdh.aushIceProgramPara ).';
+        this.freeParam   = double( mdh.aushFreePara ).';
+
+        this.memPos = filePos;
+
+    end % of readMDH
+
+    function this = tryAndFixLastMdh(this)
+        eofWarning = [mfilename() ':UnxpctdEOF'];   % We have it inside this.readData()
+        warning( 'off', eofWarning )    % silence warnings for read...
+        warning( 'off', 'foo:bar'  )    % ... and a stupid placeholder
+
+        isLastAcqGood = false;
+        cnt = 0;
+
+        while ~isLastAcqGood  &&  this.NAcq > 0  && cnt < 100
+            warning( 'foo:bar', 'baz') % make sure that lastwarn() does not return eofWarning
+            try
+                this.clean();
+                this.unsorted(this.NAcq);
+                [~, warnid] = lastwarn();
+                if strcmp( warnid, eofWarning )
+                    error( 'Make sure to go to the catch block.')
+                end
+                isLastAcqGood = true;
+            catch
+                this.isBrokenFile = true;
+                this.NAcq = this.NAcq-1;
+            end
+            cnt = cnt + 1;
+        end
+        
+%         if this.NAcq == 0  ||  cnt > 99    % everything is garbage
+%             warning(  )
+%         end
+
+        warning( 'on', eofWarning )
+    end
+
+    function this = clean(this)
+        
+        if this.NAcq == 0
+            return;
+        end
+
+        % Cut mdh data to actual size. Maybe we rejected acquisitions at the end
+        % due to read errors.
+        fields = { 'NCol', 'NCha',                                                  ...
+                   'Lin', 'Par', 'Sli', 'Ave', 'Phs', 'Eco', 'Rep',                 ...
+                   'Set', 'Seg', 'Ida', 'Idb', 'Idc', 'Idd', 'Ide',                 ...
+                   'centerCol'  ,   'centerLin',   'centerPar',           'cutOff', ...
+                   'coilSelect' , 'ROoffcenter', 'timeSinceRF',      'IsReflected', ...
+                   'scancounter',   'timestamp',     'pmutime', 'IsRawDataCorrect', ...
+                   'slicePos'   ,    'iceParam',   'freeParam',           'memPos'  };
+        
+        nack = this.NAcq;
+        idx = 1:nack;
+
+        for f = fields
+            f1 = f{1};
+            if size(this.(f1),2) > nack   % rarely
+                this.(f1) = this.(f1)(:,idx);       % 1st dim: samples,  2nd dim acquisitions
+            end
+        end
+
+        this.NLin = max(this.Lin);
+        this.NPar = max(this.Par);
+        this.NSli = max(this.Sli);
+        this.NAve = max(this.Ave);
+        this.NPhs = max(this.Phs);
+        this.NEco = max(this.Eco);
+        this.NRep = max(this.Rep);
+        this.NSet = max(this.Set);
+        this.NSeg = max(this.Seg);
+        this.NIda = max(this.Ida);
+        this.NIdb = max(this.Idb);
+        this.NIdc = max(this.Idc);
+        this.NIdd = max(this.Idd);
+        this.NIde = max(this.Ide);
+
+        % ok, let us assume for now that all NCol and NCha entries are
+        % the same for all mdhs:
+        this.NCol = this.NCol(1);
+        this.NCha = this.NCha(1);
+
+        this.dataDims = {'Col','Cha','Lin','Par','Sli','Ave','Phs',...
+            'Eco','Rep','Set','Seg','Ida','Idb','Idc','Idd','Ide'};
+
+        if strcmp(this.dataType,'refscan')
+            %pehses: check for lines with 'negative' line/partition numbers
+            %this can happen when the reference scan line/partition range
+            %exceeds the one of the actual imaging scan
+            if this.NLin>65500  %uint overflow check
+                this.Lin  = mod(this.Lin + (65536 - min(this.Lin(this.Lin>65500))),65536)+1;
+                this.NLin = max(this.Lin);
+            end
+            if this.NPar>65500  %uint overflow check
+                this.Par  = mod(this.Par + (65536 - min(this.Par(this.Par>65500))),65536)+1;
+                this.NPar = max(this.Par);
+            end
+        end
+
+        % to reduce the matrix sizes of non-image scans, the size
+        % of the refscan_obj()-matrix is reduced to the area of the
+        % actually scanned acs lines (the outer part of k-space
+        % that is not scanned is not filled with zeros)
+        % this behaviour is controlled by flagSkipToFirstLine which is
+        % set to true by default for everything but image scans
+        if ~this.flagSkipToFirstLine
+            % the output matrix should include all leading zeros
+            this.skipLin = 0;
+            this.skipPar = 0;
+        else
+            % otherwise, cut the matrix size to the start of the
+            % first actually scanned line/partition (e.g. the acs/
+            % phasecor data is only acquired in the k-space center)
+            this.skipLin = min(this.Lin)-1;
+            this.skipPar = min(this.Par)-1;
+        end
+        NLinAlloc = max(1, this.NLin - this.skipLin);
+        NParAlloc = max(1, this.NPar - this.skipPar);
+
+        this.fullSize = [ this.NCol this.NCha NLinAlloc NParAlloc...
+                          this.NSli this.NAve this.NPhs this.NEco...
+                          this.NRep this.NSet this.NSeg this.NIda...
+                          this.NIdb this.NIdc this.NIdd this.NIde ];
+
+        nByte = this.NCha*(this.freadInfo.szChannelHeader+8*this.NCol);
+
+        % size for fread
+        this.freadInfo.sz    = [2 nByte/8];
+        % reshape size
+        this.freadInfo.shape = [this.NCol+this.freadInfo.szChannelHeader/8 ...
+                               , this.NCha];
+        % we need to cut MDHs from fread data
+        this.freadInfo.cut   = this.freadInfo.szChannelHeader/8 + (1 : this.NCol);
+
+    end % of clean
+
+
+    function varargout = subsref(this, S)
+        % this is where the magic happens
+        % Now seriously. Overloading of the subsref-method and working
+        % with a gazillion indices got really messy really fast. At
+        % some point, I should probably clean this code up a bit. But
+        % good news everyone: It seems to work.
+        switch S(1).type
+            case '.'
+                % We don't want to manage method/variable calls, so we'll
+                % simply call the built-in subsref-function in this case.
+                if nargout == 0
+                    varargout{1} = builtin('subsref', this, S); % CTR fix.
+                else
+                    varargout      = cell(1, nargout);
+                    [varargout{:}] = builtin('subsref', this, S);
+                end
+                return;
+            case {'()','{}'}
+            otherwise
+                error('operator not supported');
+        end
+
+        [selRange,selRangeSz,outSize] = this.calcRange(S(1));
+
+    	% calculate page table (virtual to physical addresses)
+        % this is now done every time, i.e. result is no longer saved in
+        % a property - slower but safer (and easier to keep track of updates)
+        ixToRaw = this.calcIndices;
+        
+        tmp = reshape(1:prod(double(this.fullSize(3:end))), this.fullSize(3:end));
+        tmp = tmp(selRange{3:end});
+        ixToRaw = ixToRaw(tmp); clear tmp;
+        ixToRaw = ixToRaw(:);
+        % delete all entries that point to zero (the "NULL"-pointer)
+        notAcquired = (ixToRaw == 0);
+        ixToRaw (notAcquired) = []; clear notAcquired;
+
+        % calculate ixToTarg for possibly smaller, shifted + segmented
+        % target matrix:
+        cIx = ones(14, numel(ixToRaw), 'single');
+        if ~this.flagAverageDim(3)
+            cIx( 1,:) = this.Lin(ixToRaw) - this.skipLin;
+        end
+        if ~this.flagAverageDim(4)
+            cIx( 2,:) = this.Par(ixToRaw) - this.skipPar;
+        end
+        if ~this.flagAverageDim(5)
+            cIx( 3,:) = this.Sli(ixToRaw);
+        end
+        if ~this.flagAverageDim(6)
+            cIx( 4,:) = this.Ave(ixToRaw);
+        end
+        if ~this.flagAverageDim(7)
+            cIx( 5,:) = this.Phs(ixToRaw);
+        end
+        if ~this.flagAverageDim(8)
+            cIx( 6,:) = this.Eco(ixToRaw);
+        end
+        if ~this.flagAverageDim(9)
+            cIx( 7,:) = this.Rep(ixToRaw);
+        end
+        if ~this.flagAverageDim(10)
+            cIx( 8,:) = this.Set(ixToRaw);
+        end
+        if ~this.flagAverageDim(11)
+            cIx( 9,:) = this.Seg(ixToRaw);
+        end
+        if ~this.flagAverageDim(12)
+            cIx(10,:) = this.Ida(ixToRaw);
+        end
+        if ~this.flagAverageDim(13)
+            cIx(11,:) = this.Idb(ixToRaw);
+        end
+        if ~this.flagAverageDim(14)
+            cIx(12,:) = this.Idc(ixToRaw);
+        end
+        if ~this.flagAverageDim(15)
+            cIx(13,:) = this.Idd(ixToRaw);
+        end
+        if ~this.flagAverageDim(16)
+            cIx(14,:) = this.Ide(ixToRaw);
+        end
+
+        % make sure that indices fit inside selection range
+        for k=3:numel(selRange)
+            tmp = cIx(k-2,:);
+            for l=1:numel(selRange{k})
+                cIx(k-2,tmp==selRange{k}(l)) = l;
+            end
+        end
+
+        ixToTarg = this.sub2ind_double(selRangeSz(3:end),cIx(1,:),cIx(2,:),cIx(3,:),...
+            cIx(4,:),cIx(5,:),cIx(6,:),cIx(7,:),cIx(8,:),cIx(9,:),...
+            cIx(10,:),cIx(11,:),cIx(12,:),cIx(13,:),cIx(14,:));
+
+        mem = this.memPos(ixToRaw);
+        % sort mem for quicker access, sort cIxToTarg/Raw accordingly
+        [mem,ix]  = sort(mem);
+        ixToTarg = ixToTarg(ix);
+        ixToRaw  = ixToRaw(ix);
+        clear ix;
+
+        % For a call of type data{:,:,1:3} matlab expects more than one
+        % output variable (three in this case) and will throw an error
+        % otherwise. This is a lazy way (and the only one I know of) to
+        % fix this.
+        varargout    = cell(1, nargout);
+        varargout{1} = this.readData(mem,ixToTarg,ixToRaw,selRange,selRangeSz,outSize);
+    end % of subsref
+
+    
+    function out = unsorted(this,ival)
+        % returns the unsorted data [NCol,NCha,#samples in acq. order]
+        if ~exist('ival','var')
+            mem = this.memPos;
+        else
+            mem = this.memPos(ival);
+        end
+        out = this.readData(mem);
+    end
+
+    
+    function out = readData(this,mem,cIxToTarg,cIxToRaw,selRange,selRangeSz,outSize)
+
+        if ~exist('outSize','var')
+            selRange{1} = ':';
+            selRange{2} = ':';
+            outSize = [this.dataSize(1:2),numel(mem)];
+            selRangeSz = outSize;
+            cIxToTarg = 1:selRangeSz(3);
+            cIxToRaw  = cIxToTarg;
+        else
+            if isequal( selRange{1}(:), (1:this.dataSize(1)).' )
+                selRange{1} = ':';
+            end
+            if isequal( selRange{2}(:), (1:this.dataSize(2)).' )
+                selRange{2} = ':';
+            end
+        end
+        out = complex(zeros(outSize,'single'));
+        out = reshape(out, selRangeSz(1), selRangeSz(2), []);
+
+        if isempty( mem )
+            out = reshape(out,outSize);
+            return
+        end
+
+        cIxToTarg = this.cast2MinimalUint( cIxToTarg );
+
+        % subsref overloading makes this.that-calls slow, so we need to
+        % avoid them whenever possible
+        szScanHeader = this.freadInfo.szScanHeader;
+        readSize     = this.freadInfo.sz;
+        readShape    = this.freadInfo.shape;
+        readCut      = this.freadInfo.cut;
+        keepOS       = [1:this.NCol/4, 1+this.NCol*3/4:this.NCol];
+        bRemoveOS    = this.arg.removeOS;
+        bIsReflected = this.IsReflected( cIxToRaw );
+        bRegrid      = this.flagRampSampRegrid && numel(this.rampSampTrj);
+        slicedata    = this.slicePos(:, cIxToRaw); % HOD
+        %SRY store information about raw data correction
+        bDoRawDataCorrect = this.arg.doRawDataCorrect;
+        bIsRawDataCorrect = this.IsRawDataCorrect( cIxToRaw );
+        isBrokenRead      = false;
+        if (bDoRawDataCorrect)
+            rawDataCorrect = this.arg.rawDataCorrectionFactors;
+        end
+
+        % MiVö: Raw data are read line-by-line in portions of 2xNColxNCha float32 points (2 for complex).
+        % Computing and sorting(!) on these small portions is quite expensive, esp. when
+        % it employs non-sequential memory paths. Examples are non-linear k-space acquisition
+        % or reflected lines.
+        % This can be sped up if slightly larger blocks of raw data are collected, first.
+        % Whenever a block is full, we do all those operations and save it in the final "out" array.
+        % What's a good block size? Depends on data size and machine (probably L2/L3/L4 cache sizes).
+        % So...? Start with a small block, measure the time-per-line and double block size until
+        % a minimum is found. Seems sufficiently robust to end up in a close-to-optimal size for every
+        % machine and data.
+        blockSz   = 2;          % size of blocks; must be 2^n; will be increased
+        doLockblockSz = false;  % whether blockSZ should be left untouched
+        tprev     = inf;        % previous time-per-line
+        blockCtr  = 0;
+        blockInit = -inf(readShape(1), readShape(2), blockSz, 'single'); %init with garbage
+        blockInit = complex( blockInit );
+        block     = blockInit;
+        
+        if bRegrid
+            v1       = single(1:selRangeSz(2));
+            v2       = single(1:blockSz);
+            rsTrj    = {this.rampSampTrj,v1,v2};
+            trgTrj   = linspace(min(this.rampSampTrj),max(this.rampSampTrj),this.NCol);
+            trgTrj   = {trgTrj,v1,v2};
+        end
+    
+        % counter for proper scaling of averages/segments
+        count_ave = zeros([1 1 size(out,3)],'single');
+        kMax      = numel( mem );   % max loop index
+
+        fid = this.fileopen();
+
+        for k = 1:kMax
+            % skip scan header
+            fseek(fid,mem(k) + szScanHeader,'bof');
+            raw = fread(fid, readSize, 'float=>single').';
+
+            % MiVö: With incomplete files fread() returns less than readSize points. The subsequent reshape will therefore error out.
+            %       We could check if numel(raw) == prod(readSize), but people recommend exception handling for performance
+            %       reasons. Do it.
+            try
+                raw = reshape( complex(raw(:,1), raw(:,2)), readShape);
+            catch exc
+                offset_bytes = mem(k) + szScanHeader;
+                %remainingSz = readSize(2) - size(raw,1);
+                warning( [mfilename() ':UnxpctdEOF'],  ...
+                          [ '\nAn unexpected read error occurred at this byte offset: %d (%g GiB)\n'...
+                            'Actual read size is [%s], desired size was: [%s]\n'                    ...
+                            'Will ignore this line and stop reading.\n'                             ...
+                            '=== MATLABs error message ================\n'                          ...
+                            exc.message                                                             ...
+                            '\n=== end of error =========================\n'                        ...
+                            ], offset_bytes, offset_bytes/1024^3, num2str(size(raw)), num2str(readSize.') )
+
+                % Reject this data fragment. To do so, init with the values of blockInit
+                clear raw
+                raw( 1:prod(readShape) ) = blockInit(1);
+                raw = reshape( raw, readShape );
+                isBrokenRead = true;   % remember it and bail out later
+            end
+
+            blockCtr = blockCtr + 1;
+            block(:,:,blockCtr) = raw;  % fast serial storage in a cache array
+            
+            % Do expensive computations and reorderings on the gathered block.
+            % Unfortunately, a lot of code is necessary, but that is executed much less
+            % frequent, so its worthwhile for speed.
+            % TODO: Do *everything* block-by-block
+            if blockCtr == blockSz || k == kMax || (isBrokenRead && blockCtr > 1)
+                s = tic;    % measure the time to process a block of data
+            
+                % remove MDH data from block:
+                block = block(readCut,:,:);
+
+                if bRegrid
+                    % HOD: Start
+                    % correct for readout shifts
+                    % the nco frequency is always scaled to the max.
+                    % gradient amp and does account for ramp-sampling
+                    ro_shift = this.calcOffcenterShiftRO(slicedata(:,k));
+                    deltak = max(abs(diff(rsTrj{1})));
+                    phase = (0:this.NCol-1).' * deltak * ro_shift;
+                    phase_factor = exp(1j*2*pi*(phase - ro_shift * rsTrj{1}));
+                    block = bsxfun(@times, block, phase_factor);
+                    % HOD: Stop
+                    F     = griddedInterpolant(rsTrj,block);
+                    block = F(trgTrj);
+                end
+%                 % HOD: Start. Moved down by UK?
+%                 ix = 1 + k - blockCtr : k;
+%                 if blockCtr ~= blockSz
+%                     block = block(:,:,1:blockCtr);
+%                 end
+%                 % HOD: Stop
+                
+                if sum(isnan(block(:)))>0
+                    keyboard
+                end
+
+                if bRemoveOS % remove oversampling in read
+                    block = ifft( block,[],1);
+                    block =  fft( block(keepOS,:,:),[],1);
+                end
+                                    
+                if ( bDoRawDataCorrect && bIsRawDataCorrect(k) )
+                    %SRY apply raw data correction if necessary
+                    block = bsxfun(@times, block, rawDataCorrect);
+                end
+                
+                ix = 1 + k - blockCtr : k;
+                if blockCtr ~= blockSz
+                    block = block(:,:,1:blockCtr);
+                end
+                
+                isRefl = bIsReflected(ix);
+                block(:,:,isRefl) = block(end:-1:1,:,isRefl);
+                
+                if ~isequal(selRange{1},':') || ~isequal(selRange{2},':')
+                    block = block( selRange{1}, selRange{2}, : );    % a bit slow
+                end
+                
+                [sortIdx, I] = sort( cIxToTarg(ix), 'ascend' );
+                block = block(:,:,I);     % reorder according to sorted target indices
+
+                % Mark duplicate indices with 1; we'll have to treat them special for proper averaging
+                % Bonus: The very first storage can be made much faster, because it's in-place.
+                %        Matlab urgently needs a "+=" operater, which makes "A(:,:,idx) = A(:,:,idx) + B"
+                %        in-place and more readable.
+                isDupe  = [ false, diff(sortIdx) == 0 ];
+
+                idx1 = sortIdx(~isDupe);     % acquired once in this block
+                idxN = sortIdx( isDupe);     % acquired multiple times
+
+                count_ave(idx1) = count_ave(idx1) + 1;
+
+                if isempty( idxN )
+                    % no duplicates
+                    if all( count_ave(idx1) == 1 )  % first acquisition of this line
+                        out(:,:,idx1) = block;                              % fast
+                    else
+                        out(:,:,idx1) = out(:,:,idx1) + block;              % slow
+                    end
+                else
+                    out(:,:,idx1) = out(:,:,idx1) + block(:,:,~isDupe);     % slower
+
+                    block = block(:,:,isDupe);
+                    for n = 1:numel(idxN)
+                        out(:,:,idxN(n)) = out(:,:,idxN(n)) + block(:,:,n); % snail :-)
+                        count_ave(idxN(n)) = count_ave(idxN(n)) + 1;
+                    end
+                end
+
+                % At the first few iterations, evaluate the spent time-per-line and decide
+                % what to do with the block size.
+                if ~doLockblockSz
+                    t = 1e6 * toc(s)/blockSz;   % micro seconds
+
+                    if t <= 1.1 * tprev % allow 10% inaccuracy. Usually bigger == better
+                        % New block size was faster. Go a step further.
+                        blockSz = blockSz * 2;
+                        blockInit = cat(3, blockInit, blockInit);
+                    else
+                        % regression; reset size and lock it
+                        blockSz = max( blockSz/2, 1 );
+                        blockInit = blockInit(:,:,1:blockSz);
+                        doLockblockSz = true;
+                    end
+                    if bRegrid
+                        rsTrj{3}  = single(1:blockSz);
+                        trgTrj{3} = rsTrj{3};
+                    end
+                    tprev = t;
+                end
+                    
+                blockCtr = 0;
+                block = blockInit;  % reset to garbage
+            end
+
+            if isBrokenRead
+                this.isBrokenFile = true;
+                break
+            end
+        end
+
+        fclose(fid);
+
+        % proper scaling (we don't want to sum our data but average it)
+        % For large "out" bsxfun(@rdivide,out,count_ave) is incredibly faster than
+        % bsxfun(@times,out,count_ave)!
+        % @rdivide is also running in parallel, while @times is not. :-/
+        if any( reshape(count_ave,[],1) > 1 )
+            clearvars -except  out  count_ave  outSize
+            count_ave = max( 1, count_ave );
+            out       = bsxfun( @rdivide, out, count_ave);
+        end
+
+        out = reshape(out,outSize);
+    end % of readData
+
+
+    function setDefaultFlags(this)
+        % method to set flags to default values
+        this.arg.removeOS            = false;
+        this.arg.rampSampRegrid      = false;
+        this.arg.doAverage           = false;
+        this.arg.averageReps         = false;
+        this.arg.averageSets         = false;
+        this.arg.ignoreSeg           = false;
+        this.arg.doRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        if ~isfield(this.arg,'rawDataCorrectionFactors')
+            this.arg.rawDataCorrectionFactors = [];
+        end
+    end
+
+    function dummy = resetFlags(this)
+        % method to reset flags to default values
+        this.flagRemoveOS            = false;
+        this.flagRampSampRegrid      = false;
+        this.flagDoRawDataCorrect    = false;
+        this.flagAverageDim          = false(1,16);
+        
+        if strcmp(this.dataType,'image') || strcmp(this.dataType,'phasecor') || strcmp(this.dataType,'phasestab')
+            this.arg.skipToFirstLine = false;
+        else
+            this.arg.skipToFirstLine = true;
+        end
+        dummy = [];
+    end
+    
+%     % HOD: Added
+%     function versiontime = get.readerVersion(~)
+%         % returns utc-unixtime of last commit (from file precommit-unixtime)
+%         p = fileparts(mfilename('fullpath'));
+%         fid = fopen(fullfile(p, 'precommit_unixtime'));
+%         versiontime = uint64(str2double(fgetl(fid)));
+%         fclose(fid);
+%     end
+    
+    function out = get.dataSize(this)
+        out = this.fullSize;
+        
+        if this.arg.removeOS
+            ix = ismember(this.dataDims, 'Col');
+            out(ix) = this.NCol/2;
+        end
+                
+        if this.flagAverageDim(1) || this.flagAverageDim(2)
+            warning('averaging in col and cha dim not supported, resetting flag');
+            this.flagAverageDim(1:2) = false;
+        end
+        
+        out(this.flagAverageDim) = 1;
+    end
+    
+    % HOD: Added
+    function out = get.sqzDims(this)
+        out = this.dataDims(this.dataSize>1);
+    end    
+    
+    function out = get.sqzSize(this)
+        % calculate sqzSize and sqzDims
+        out = this.dataSize(1);
+        this.sqzDims    = [];
+        this.sqzDims{1} = 'Col';
+        c = 1;
+        for k=2:numel(this.dataSize)
+            if this.dataSize(k)>1
+                c = c+1;
+                out(c) = this.dataSize(k);
+                this.sqzDims{c} = this.dataDims{k};
+            end
+        end
+    end
+    
+        
+    function set.flagRemoveOS(this,val)
+        % set method for removeOS
+        this.arg.removeOS = logical(val);
+    end
+    
+    function out = get.flagRemoveOS(this)
+        out = this.arg.removeOS;
+    end
+
+
+    function set.flagDoAverage(this,val)
+        ix = ismember(this.dataDims, 'Ave');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagDoAverage(this)
+        ix = ismember(this.dataDims, 'Ave');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagAverageReps(this,val)
+        ix = ismember(this.dataDims, 'Rep');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageReps(this)
+        ix = ismember(this.dataDims, 'Rep');
+        out = this.flagAverageDim(ix);
+    end
+
+
+    function set.flagAverageSets(this,val)
+        ix = ismember(this.dataDims, 'Set');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagAverageSets(this)
+        ix = ismember(this.dataDims, 'Set');
+        out = this.flagAverageDim(ix);
+    end
+
+    
+    function set.flagIgnoreSeg(this,val)
+        ix = ismember(this.dataDims, 'Seg');
+        this.flagAverageDim(ix) = val;
+    end
+
+
+    function out = get.flagIgnoreSeg(this)
+        ix = ismember(this.dataDims, 'Seg');
+        out = this.flagAverageDim(ix);
+    end
+
+    %DLP 17 Dec 2018
+    function set.flagIgnoreIda(this,val)                %DLP (7 December 2018) added this flag to sum over baselines 
+        ix = ismember(this.dataDims, 'Ida');            % to eliminate sparse data structure
+        this.flagAverageDim(ix) = val;
+    end
+    function out = get.flagIgnoreIda(this)
+        ix = ismember(this.dataDims, 'Ida');
+        out = this.flagAverageDim(ix);
+    end
+ % end DLP 17 Dec 2018   
+    
+    function set.flagSkipToFirstLine(this,val)
+        val = logical(val);
+        if val ~= this.arg.skipToFirstLine
+            this.arg.skipToFirstLine = val;
+
+            if this.arg.skipToFirstLine
+                this.skipLin = min(this.Lin)-1;
+                this.skipPar = min(this.Par)-1;
+            else
+                this.skipLin = 0;
+                this.skipPar = 0;
+            end
+            NLinAlloc = max(1, this.NLin - this.skipLin);
+            NParAlloc = max(1, this.NPar - this.skipPar);
+            this.fullSize(3:4) = [NLinAlloc NParAlloc];
+        end
+    end
+
+
+    function out = get.flagSkipToFirstLine(this)
+        out = this.arg.skipToFirstLine;
+    end
+
+    function out = get.flagRampSampRegrid(this)
+        out = this.arg.rampSampRegrid;
+    end
+
+    function set.flagRampSampRegrid(this, val)
+        val = logical(val);
+        if (val == true && isempty(this.rampSampTrj))
+            error('No trajectory for regridding available');
+        end
+        this.arg.rampSampRegrid = val;
+    end
+
+    %SRY: accessor methods for raw data correction
+    function out = get.flagDoRawDataCorrect(this)
+        out = this.arg.doRawDataCorrect;
+    end
+
+    function set.flagDoRawDataCorrect(this, val)
+        val = logical(val);
+        if (val == true && strcmp(this.softwareVersion, 'vd'))
+            error('raw data correction for VD not supported/tested yet');
+        end
+
+        this.arg.doRawDataCorrect = val;
+    end
+
+    function out = get.RawDataCorrectionFactors(this)
+        out = this.arg.rawDataCorrectionFactors;
+    end
+
+    function set.RawDataCorrectionFactors(this, val)
+        %this may not work if trying to set the factors before NCha has
+        %a meaningful value (ie before calling clean)
+        if (~isrow(val) || length(val) ~= this.NCha)
+            error('RawDataCorrectionFactors must be a 1xNCha row vector');
+        end
+        this.arg.rawDataCorrectionFactors = val;
+    end
+
+end
+
+methods (Access='protected')
+    % helper functions
+
+    function fid = fileopen(this)
+        % look out for unlikely event that someone is switching between
+        % windows and unix systems:
+        [path,name,ext] = fileparts(this.filename);
+        this.filename   = fullfile(path,[name ext]);
+
+        % test access
+        if numel(dir(this.filename))==0
+            % update path when file of same name can be found in current
+            % working dir. -- otherwise throw error
+            [oldpath,name,ext] = fileparts(this.filename);
+            newloc = fullfile(pwd,[name ext]);
+            if numel(dir(newloc))==1
+                fprintf('Warning: File location updated from "%s" to current working directory.\n',oldpath);
+                this.filename = newloc;
+            else
+                error(['File "' this.filename '" not found.']);
+            end
+        end
+        fid = fopen(this.filename);
+    end
+
+    
+    function [selRange,selRangeSz,outSize] = calcRange(this,S)
+
+        switch S.type
+            case '()'
+                bSqueeze = false;
+            case '{}'
+                bSqueeze = true;
+        end
+
+        selRange = num2cell(ones(1,numel(this.dataSize)));
+        outSize  = ones(1,numel(this.dataSize));
+
+        if ( isempty(S.subs) || strcmpi(S.subs(1),'') )
+            % obj(): shortcut to select all data
+            % unfortunately, matlab does not allow the statement
+            % obj{}, so we can't use it...
+            % alternative: obj{''} (obj('') also works)
+            for k=1:numel(this.dataSize)
+                selRange{k}   = 1:this.dataSize(k);
+            end
+            if ~bSqueeze
+                outSize = this.dataSize;
+            else
+                outSize = this.sqzSize;
+            end
+        else
+            for k=1:numel(S.subs)
+                if ~bSqueeze
+                    cDim = k; % nothing to do
+                else
+                    % we need to rearrange selRange from squeezed
+                    % to original order
+                    cDim = find(strcmp(this.dataDims,this.sqzDims{k}) == 1);
+                end
+                if strcmp(S.subs{k},':')
+                    if k<numel(S.subs)
+                        selRange  {cDim} = 1:this.dataSize(cDim);
+                    else % all later dimensions selected and 'vectorized'!
+                        for l=cDim:numel(this.dataSize)
+                            selRange{l} = 1:this.dataSize(l);
+                        end
+                        outSize(k) = prod(double(this.dataSize(cDim:end)));
+                        break; % jump out ouf for-loop
+                    end
+                elseif isnumeric(S.subs{k})
+                    selRange{cDim} = single(S.subs{k});
+                else
+                    error('unknown string in brackets (e.g. 1:end does not work here)');
+                end
+                outSize(k) = numel(selRange{cDim});
+            end
+            for k=1:numel(selRange)
+                if max(selRange{k}) > this.dataSize(k)
+                    error('selection out of range');
+                end
+            end
+        end
+
+        selRangeSz = ones(1,numel(this.dataSize));
+        for k=1:numel(selRange)
+            selRangeSz(k) = numel(selRange{k});
+        end
+        
+        % now select all indices for the dims that are averaged
+        for k = find(this.flagAverageDim)
+            selRange{k} = 1:this.fullSize(k);
+        end
+    end
+
+    
+    function [ixToRaw, ixToTarget] = calcIndices(this)
+        % calculate indices to target & source(raw)
+        LinIx     = this.Lin - this.skipLin;
+        ParIx     = this.Par - this.skipPar;
+        ixToTarget = this.sub2ind_double(this.fullSize(3:end),...
+            LinIx, ParIx, this.Sli, this.Ave, this.Phs, this.Eco,...
+            this.Rep, this.Set, this.Seg, this.Ida, this.Idb,...
+            this.Idc, this.Idd, this.Ide);
+
+        % now calc. inverse index (page table: virtual to physical addresses)
+        % indices of lines that are not measured are zero
+        ixToRaw = zeros(1,prod(this.fullSize(3:end)),'double');
+
+        ixToRaw(ixToTarget) = 1:numel(ixToTarget);
+    end
+end
+
+methods (Static)
+    % helper functions, accessible from outside via <classname>.function()
+    % without an instance of the class.
+
+    % HOD: Added
+    function ro_shift = calcOffcenterShiftRO(slicedata)
+        % calculate ro offcenter shift from mdh's slicedata
+        
+        % slice position
+        pos = slicedata(1:3);
+        
+        %quaternion
+        a = slicedata(5);
+        b = slicedata(6);
+        c = slicedata(7);
+        d = slicedata(4);
+        
+        read_dir = zeros(3,1);
+        read_dir(1) = 2 * (a * b - c * d);
+        read_dir(2) = 1 - 2 * (a^2 + c^2);
+        read_dir(3) = 2 * (b * c + a * d);
+    
+        ro_shift = dot(pos, read_dir);
+    end 
+    
+    function ndx = sub2ind_double(sz,varargin)
+        %SUB2IND_double Linear index from multiple subscripts.
+        %   Works like sub2ind but always returns double
+        %   also slightly faster, but no checks
+        %========================================
+        sz  = double(sz);
+        ndx = double(varargin{end}) - 1;
+        for i = length(sz)-1:-1:1
+            ix  = double(varargin{i});
+            ndx = sz(i)*ndx + ix-1;
+        end
+        ndx = ndx + 1;
+    end % sub2ind_double
+
+    function N = cast2MinimalUint( N )
+        Nmax = max( reshape(N,[],1) );
+        Nmin = min( reshape(N,[],1) );
+        if Nmin < 0 || Nmax > intmax('uint64')
+            return
+        end
+
+        if Nmax > intmax('uint32')
+            idxClass = 'uint64';
+        elseif Nmax > intmax('uint16')
+            idxClass = 'uint32';
+        else
+            idxClass = 'uint16';
+        end
+
+        N = cast( N, idxClass );
+    end % cast2MinimalUint()
+
+end % of methods (Static)
+
+end % classdef

--- a/matlab/read_kspace_dependencies/read_kspace__script.m
+++ b/matlab/read_kspace_dependencies/read_kspace__script.m
@@ -1,0 +1,18 @@
+addpath(genpath('/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/mri-recon/matlab/read_kspace/'))
+
+sourceDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/mri-recon/test-data/seg-epi/multichannel-phantom/';
+saveDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/matlab-sara-WIP/read_kspace/';
+
+rawfileName = 'meas_MID00262_FID27298_BRIFU_MRTI_XA50_1p2x0p6x1p8_ETL5_paddleCoil.dat';
+
+fast_read_options = {'NoFillToFullFourier',...
+                    'ShiftDCToMatrixCenter',...
+                    'NoGUI',...
+                    'LastMeasDatOnly',...
+                    'CollapseSeg',...
+                    'ReadNoiseAdj'};
+
+
+ReconData = read_kspace(sourceDir, rawfileName, fast_read_options); 
+
+save([saveDir 'ks_' rawfileName(1:end-4)], 'ReconData'); 

--- a/matlab/read_kspace_dependencies/read_kspace__script.m
+++ b/matlab/read_kspace_dependencies/read_kspace__script.m
@@ -1,7 +1,7 @@
-addpath(genpath('/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/mri-recon/matlab/read_kspace/'))
+addpath(genpath('/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/mri-recon/matlab/read_kspace_dependencies/'))
 
 sourceDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/mri-recon/test-data/seg-epi/multichannel-phantom/';
-saveDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/matlab-sara-WIP/read_kspace/';
+saveDir = '/System/Volumes/Data/v/raid10/users/sjohnson/Matlab Code/mri_recon_framework/matlab-sara-WIP/';
 
 rawfileName = 'meas_MID00262_FID27298_BRIFU_MRTI_XA50_1p2x0p6x1p8_ETL5_paddleCoil.dat';
 


### PR DESCRIPTION
The 'read_kspace.m' function first creates the typical "header" variable by calling 'jGetFileInfo' directly, then reads in kspace using 'fast_read_ve11' (without the ReadFileInfo option). Finally, more metadata is read-in into the "shd" variable by calling 'mapVDVB_uk.m.' 

'read_kspace.m' specifies default options for 'fast_read_ve11.m,' but these options can be overridden by passing a cell array input (fast_read_options). The default options do not include multislice-related information (ReadSVector, etc). However, after jGetFileInfo is called, 'read_kspace.m' checks if MRI acquisition was mutlislice. If so, then the options for 'fast_read_ve11.m' are amended to include the necessary multislice info, which is appended to the "header" variable. 

All data and metadata is output into a struct called 'ReconData.' An example script is given in /read_kspace_dependencies. 